### PR TITLE
upgrade: git-versioning v1.1.0 → v1.2.0 — session branch gate

### DIFF
--- a/.ai/.CLAUDE.md
+++ b/.ai/.CLAUDE.md
@@ -34,7 +34,7 @@ The project utilizes a tiered AI harness to coordinate Claude, Codex, and Gemini
 
 ## Registered Agents
 <!-- @agent-registry:start -->
-- **test-agent**: Specialized agent for Git workflows, semantic versioning, and project state management. (See: `.ai/agents/test-agent/docs/CLAUDE.md`)
+- **test-agent**: Manual Description (See: `.ai/agents/test-agent/docs/CLAUDE.md`)
 - **test-claude-agent**: AgentFactory-powered agent demonstrating a minimal Claude-native agent layout. (See: `.ai/agents/test-claude-agent/docs/CLAUDE.md`)
 - **test-intel-agent**: AgentFactory-powered agent demonstrating intelligence-layer features: dependency detection and sk... (See: `.ai/agents/test-intel-agent/docs/CLAUDE.md`)
 <!-- @agent-registry:end -->

--- a/.ai/agents/test-agent/skills/git-versioning/SKILL.md
+++ b/.ai/agents/test-agent/skills/git-versioning/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: git-versioning
-version: 1.1.0
+version: 1.2.0
 description: >
   Git and versioning workflow assistant for any project using the versioning template.
   Handles commit, branch, PR, merge, tag, release, rollback, and inspection.
   Reads all project-specific values (remote URL, branch, versions) from
   skills/git-versioning/references/repo-state.md — no hardcoded project names.
+  Enforces a session branch gate: no edits are allowed directly on the default branch.
   Trigger when the user wants to commit, push, open a PR, merge, tag, release,
   rollback an artifact, or asks "what should I do next" in a git context.
 ---
 
-# Git Versioning Assistant — v1.1.0
+# Git Versioning Assistant — v1.2.0
 
 ---
 
@@ -27,6 +28,30 @@ Use these values in every command and message. Never hardcode them.
 
 If `repo-state.md` has unfilled placeholders, stop and tell the user:
 > "Please fill in the Remote section of `skills/git-versioning/references/repo-state.md` before continuing."
+
+---
+
+## Step 0.5 — Session Branch Gate (run every session before any edit)
+
+Run these two commands immediately after loading context:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+Then apply the gate:
+
+| State | Action |
+|-------|--------|
+| On `DEFAULT_BRANCH`, working tree **clean** | **STOP.** Tell the user: "You're on `DEFAULT_BRANCH`. Create a branch before making any changes:" then output the branch creation command. Do not proceed until the user confirms they are on a non-default branch. |
+| On `DEFAULT_BRANCH`, working tree **dirty** (uncommitted changes) | **EMERGENCY STOP.** Tell the user: "You have uncommitted changes directly on `DEFAULT_BRANCH` — this puts the stable release at risk. Stash your changes and move them to a feature branch:" then output the stash + branch + pop commands. Do not commit to `DEFAULT_BRANCH`. |
+| On a non-default branch, working tree **clean** | Confirm: "Working on branch `<branch>` — ready to proceed." Continue to Step 1. |
+| On a non-default branch, working tree **dirty** | Confirm: "Working on branch `<branch>` with uncommitted changes." Continue to Step 1. |
+
+**Why this matters**: `DEFAULT_BRANCH` represents the last stable tagged release. Any direct commit to it makes rollback harder and risks overwriting a known-good state. All work — even a one-line fix — must be done on a branch, reviewed via PR, and merged cleanly.
+
+**Never skip this gate.** Even if the user says "just make a quick fix" or "it's only a typo", direct commits to `DEFAULT_BRANCH` are always wrong.
 
 ---
 

--- a/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
+++ b/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
@@ -30,7 +30,7 @@ Latest tag: v2.1.1
 
 | Skill | Version | Path |
 |-------|---------|------|
-| git-versioning | v1.1.0 | skills/git-versioning/SKILL.md |
+| git-versioning | v1.2.0 | skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | skills/diff-visualizer/SKILL.md |
 
 ---

--- a/.ai/agents/test-agent/skills/git-versioning/skill-manifest.json
+++ b/.ai/agents/test-agent/skills/git-versioning/skill-manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "git-versioning",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manages project-wide versioning and repo-state.md updates."
 }

--- a/.ai/skills/git-versioning/SKILL.md
+++ b/.ai/skills/git-versioning/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: git-versioning
-version: 1.1.0
+version: 1.2.0
 description: >
   Git and versioning workflow assistant for any project using the versioning template.
   Handles commit, branch, PR, merge, tag, release, rollback, and inspection.
   Reads all project-specific values (remote URL, branch, versions) from
   skills/git-versioning/references/repo-state.md — no hardcoded project names.
+  Enforces a session branch gate: no edits are allowed directly on the default branch.
   Trigger when the user wants to commit, push, open a PR, merge, tag, release,
   rollback an artifact, or asks "what should I do next" in a git context.
 ---
 
-# Git Versioning Assistant — v1.1.0
+# Git Versioning Assistant — v1.2.0
 
 ---
 
@@ -27,6 +28,30 @@ Use these values in every command and message. Never hardcode them.
 
 If `repo-state.md` has unfilled placeholders, stop and tell the user:
 > "Please fill in the Remote section of `skills/git-versioning/references/repo-state.md` before continuing."
+
+---
+
+## Step 0.5 — Session Branch Gate (run every session before any edit)
+
+Run these two commands immediately after loading context:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+Then apply the gate:
+
+| State | Action |
+|-------|--------|
+| On `DEFAULT_BRANCH`, working tree **clean** | **STOP.** Tell the user: "You're on `DEFAULT_BRANCH`. Create a branch before making any changes:" then output the branch creation command. Do not proceed until the user confirms they are on a non-default branch. |
+| On `DEFAULT_BRANCH`, working tree **dirty** (uncommitted changes) | **EMERGENCY STOP.** Tell the user: "You have uncommitted changes directly on `DEFAULT_BRANCH` — this puts the stable release at risk. Stash your changes and move them to a feature branch:" then output the stash + branch + pop commands. Do not commit to `DEFAULT_BRANCH`. |
+| On a non-default branch, working tree **clean** | Confirm: "Working on branch `<branch>` — ready to proceed." Continue to Step 1. |
+| On a non-default branch, working tree **dirty** | Confirm: "Working on branch `<branch>` with uncommitted changes." Continue to Step 1. |
+
+**Why this matters**: `DEFAULT_BRANCH` represents the last stable tagged release. Any direct commit to it makes rollback harder and risks overwriting a known-good state. All work — even a one-line fix — must be done on a branch, reviewed via PR, and merged cleanly.
+
+**Never skip this gate.** Even if the user says "just make a quick fix" or "it's only a typo", direct commits to `DEFAULT_BRANCH` are always wrong.
 
 ---
 

--- a/.ai/skills/git-versioning/references/repo-state.md
+++ b/.ai/skills/git-versioning/references/repo-state.md
@@ -31,7 +31,7 @@ Latest tag: v2.1.1
 | Artifact | Version | Path |
 |----------|---------|------|
 | agent-gen CLI | v0.2.0 | pyproject.toml |
-| git-versioning | v1.1.0 | .ai/skills/git-versioning/SKILL.md |
+| git-versioning | v1.2.0 | .ai/skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | .ai/skills/diff-visualizer/SKILL.md |
 
 ---

--- a/.ai/skills/git-versioning/skill-manifest.json
+++ b/.ai/skills/git-versioning/skill-manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "git-versioning",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Manages project-wide versioning and repo-state.md updates."
 }


### PR DESCRIPTION
## Summary
- Adds **Step 0.5 (Session Branch Gate)** to `git-versioning` skill
- At the start of every session, the skill now runs `git branch --show-current` + `git status --short` and gates all work based on the result
- If on `DEFAULT_BRANCH` (clean): stops and requires branch creation before proceeding
- If on `DEFAULT_BRANCH` (dirty): emergency stop — guides user to stash + move to feature branch
- If already on a feature branch: confirms and proceeds
- Includes explicit "never skip" rule to close the "quick fix" loophole

## Why
Direct commits to the default branch bypass the PR review flow, making rollback harder and risking overwrites of stable tagged releases. Every edit — even a typo — must live on a branch.

## Test plan
- [ ] Load skill in a new session while on `dev` branch — verify it outputs branch creation command and refuses to proceed
- [ ] `Librarian.audit()` on test-agent → CLEAN (no version drift)
- [ ] `pytest tests/ -q` → 16 passed