### PR TITLE
chore: update repo-state.md for v2.2.0

### DIFF
--- a/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
+++ b/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
@@ -21,8 +21,9 @@ The git-versioning skill reads this to give accurate, repo-specific commands.
 | v2.0.0 | 764f1df | .ai/ harness consolidation — single .CLAUDE.md source of truth |
 | v2.1.0 | d94ae42 | Librarian intelligence layer enhancements + registry auto-population |
 | v2.1.1 | 91313c3 | Harness cleanup + audit gap detection (version drift, repo-state staleness) |
+| v2.2.0 | c2d5dfc | git-versioning v1.2.0: session branch gate enforcement |
 
-Latest tag: v2.1.1
+Latest tag: v2.2.0
 
 ---
 

--- a/.ai/skills/git-versioning/references/repo-state.md
+++ b/.ai/skills/git-versioning/references/repo-state.md
@@ -21,8 +21,9 @@ The git-versioning skill reads this to give accurate, repo-specific commands.
 | v2.0.0 | b6d8f46 | Unified multi-CLI harness + Librarian intelligence layer |
 | v2.1.0 | da02586 | .ai/ harness consolidation + agent-gen init + complete adapter wiring |
 | v2.1.1 | 91313c3 | Harness cleanup + audit gap detection (version drift, repo-state staleness) |
+| v2.2.0 | c2d5dfc | git-versioning v1.2.0: session branch gate enforcement |
 
-Latest tag: v2.1.1
+Latest tag: v2.2.0
 
 ---
 


### PR DESCRIPTION
Adds v2.2.0 tag entry to both repo-state.md copies.