### PR TITLE
feat: agent-gen import --from-git — remote repo import pipeline

### DIFF
--- a/agent_gen/cli.py
+++ b/agent_gen/cli.py
@@ -2,6 +2,9 @@
 
 import os
 import sys
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 import click
@@ -20,6 +23,67 @@ def _agent_root(name: str) -> Path:
     if not new.parent.exists() and legacy.parent.exists():
         return legacy
     return new
+
+
+def _clone_and_prepare(url: str) -> tuple[str, object]:
+    """
+    Clone a git URL, retrofit it to AgentFactory standard, and wrap it as a ZIP.
+
+    Returns:
+        (zip_path_str, cleanup_fn) — caller must call cleanup_fn() after import.
+    """
+    # Derive agent name from URL
+    name = url.rstrip("/").split("/")[-1]
+    if name.endswith(".git"):
+        name = name[:-4]
+
+    tmp_dir = tempfile.mkdtemp(prefix="agentfactory_import_")
+    cloned_dir = os.path.join(tmp_dir, name)
+
+    try:
+        click.echo(f"[librarian] Cloning {url} ...")
+        result = subprocess.run(
+            ["git", "clone", url, cloned_dir],
+            capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            raise click.ClickException(
+                f"git clone failed:\n{result.stderr.strip()}"
+            )
+
+        # 1. Extract context from source BEFORE retrofit
+        click.echo("[librarian] Extracting context from source docs ...")
+        context = Librarian._extract_source_context(cloned_dir)
+
+        # 2. Retrofit if needed
+        profile, mapping = Librarian.propose_retrofit(cloned_dir)
+        if mapping:
+            click.echo(f"[librarian] Retrofitting (profile: {profile}) ...")
+            Librarian(cloned_dir).migrate(mapping)
+
+        # 3. Promote sub-agent .md files and create skill-manifest.json stubs
+        click.echo("[librarian] Generating skill manifests ...")
+        Librarian._auto_stub_skill_manifests(cloned_dir, context)
+
+        # 4. Init + patch manifest description + sync resources
+        click.echo("[librarian] Initialising agent manifest ...")
+        Librarian._auto_init_agent_manifest(cloned_dir, name, context)
+
+        # 5. Wrap into a ZIP
+        click.echo("[librarian] Wrapping into portable unit ...")
+        zip_path = Librarian(cloned_dir).wrap(tmp_dir)
+
+        def _cleanup():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        return str(zip_path), _cleanup
+
+    except click.ClickException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+    except Exception as exc:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise click.ClickException(f"Preparation failed: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -447,22 +511,41 @@ def import_skill(path: str, target_agent: str):
 # ---------------------------------------------------------------------------
 
 @cli.command("import")
-@click.argument("zip_path")
+@click.argument("zip_path", required=False, default=None)
+@click.option(
+    "--from-git",
+    "from_git",
+    default=None,
+    metavar="URL",
+    help="Git URL to clone, retrofit, and import as an agent (skips ZIP_PATH).",
+)
 @click.option(
     "--project-root",
     default=".",
     show_default=True,
     help="Root of the project receiving the import (for the Handshake).",
 )
-def import_agent(zip_path: str, project_root: str):
+def import_agent(zip_path: str, from_git: str, project_root: str):
     """
     Unpack a portable agent bundle and register it in this project.
+
+    Accepts either a local ZIP_PATH or --from-git URL (git clone + auto-retrofit).
 
     Steps:
       1. Unpack <zip_path> into agents/<name>/
       2. Read the embedded manifest
       3. Handshake: update this project's global agent-manifest.json
     """
+    _cleanup = None
+
+    if not zip_path and not from_git:
+        raise click.UsageError("Provide either ZIP_PATH or --from-git URL.")
+    if zip_path and from_git:
+        raise click.UsageError("ZIP_PATH and --from-git are mutually exclusive.")
+
+    if from_git:
+        zip_path, _cleanup = _clone_and_prepare(from_git)
+
     zip_path = Path(zip_path).resolve()
 
     if not zip_path.exists():
@@ -511,6 +594,10 @@ def import_agent(zip_path: str, project_root: str):
 
     click.echo(f"[librarian] Registering '{name}' in project manifest...")
     Librarian.register_in_project(manifest, project_root)
+
+    # Clean up temp dir from --from-git clone
+    if _cleanup:
+        _cleanup()
 
     # Success summary (paste-ready for Claude)
     skills = manifest["resources"].get("skills", [])

--- a/agent_gen/librarian.py
+++ b/agent_gen/librarian.py
@@ -14,6 +14,50 @@ HARNESS_ROOT = ".ai"
 CONTEXT_FILE = ".CLAUDE.md"  # single source of truth for all CLI instructions
 
 
+def _extract_first_paragraph(path: Path) -> str:
+    """
+    Extract the first meaningful paragraph from a Markdown file.
+    Skips YAML frontmatter (--- blocks), blank lines, and # headers.
+    Returns up to 200 chars of the first descriptive sentence/paragraph.
+    """
+    try:
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        lines = content.splitlines()
+        in_frontmatter = False
+        collect = []
+        i = 0
+        # Skip YAML frontmatter
+        if lines and lines[0].strip() == "---":
+            in_frontmatter = True
+            i = 1
+            while i < len(lines):
+                if lines[i].strip() == "---":
+                    i += 1
+                    break
+                i += 1
+        # Collect first non-header, non-empty, non-comment paragraph
+        for line in lines[i:]:
+            stripped = line.strip()
+            if not stripped:
+                if collect:
+                    break
+                continue
+            if stripped.startswith("#"):
+                if collect:
+                    break
+                continue
+            # Skip HTML comments (<!-- ... -->)
+            if stripped.startswith("<!--"):
+                continue
+            collect.append(stripped)
+            if len(" ".join(collect)) >= 200:
+                break
+        text = " ".join(collect).strip()
+        return text[:200] if text else ""
+    except Exception:
+        return ""
+
+
 def _git_ref(path: str) -> str:
     try:
         return subprocess.check_output(
@@ -778,6 +822,94 @@ class Librarian:
 
         # Ensure adapter symlink wiring is complete after every harness update
         cls._ensure_adapter_wiring(project_root)
+
+    # ------------------------------------------------------------------
+    # Remote import helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_source_context(source_dir: str) -> dict:
+        """
+        Read CLAUDE.md, AGENTS.md, and .claude/agents/*.md from a raw repo
+        BEFORE retrofit to extract agent and sub-agent descriptions.
+
+        Returns:
+            {"description": str, "agents": {name: str}}
+        """
+        root = Path(source_dir).resolve()
+        ctx: dict = {"description": "", "agents": {}}
+
+        # Agent-level description: README is the most reliable source for a project
+        # description; CLAUDE.md / AGENTS.md often contain instructions, not descriptions.
+        for candidate in ["README.md", "CLAUDE.md", "AGENTS.md", ".ai/.CLAUDE.md"]:
+            f = root / candidate
+            if f.exists():
+                desc = _extract_first_paragraph(f)
+                if desc:
+                    ctx["description"] = desc
+                    break
+
+        # Sub-agent descriptions from .claude/agents/*.md
+        agents_dir = root / ".claude" / "agents"
+        if agents_dir.exists():
+            for md in sorted(agents_dir.glob("*.md")):
+                desc = _extract_first_paragraph(md)
+                ctx["agents"][md.stem] = desc
+
+        return ctx
+
+    @staticmethod
+    def _auto_init_agent_manifest(agent_dir: str, name: str, context: dict) -> None:
+        """
+        Create agent-manifest.json (via init()) if missing, patch description
+        from extracted context, then sync resources from disk.
+        """
+        lib = Librarian(agent_dir)
+        if not lib.manifest_path.exists():
+            lib.init(name)
+        if context.get("description"):
+            manifest = lib._load_manifest()
+            manifest["description"] = context["description"][:200]
+            lib._save_manifest(manifest)
+        lib.sync()
+
+    @staticmethod
+    def _auto_stub_skill_manifests(agent_dir: str, context: dict) -> None:
+        """
+        After retrofit, scan orchestration/agents/ and skills/ for flat .md files
+        without a skill-manifest.json. For each, promote it to a subdirectory and
+        create a skill-manifest.json stub with description from extracted context.
+        """
+        root = Path(agent_dir).resolve()
+        scan_dirs = [root / "orchestration" / "agents", root / "skills"]
+        for scan_dir in scan_dirs:
+            if not scan_dir.exists():
+                continue
+            # Snapshot list before we start moving files
+            md_files = list(scan_dir.glob("*.md"))
+            for md_file in md_files:
+                stem = md_file.stem
+                # Promote flat .md into a named subdirectory
+                skill_dir = scan_dir / stem
+                skill_dir.mkdir(exist_ok=True)
+                dest_md = skill_dir / md_file.name
+                if not dest_md.exists():
+                    shutil.move(str(md_file), str(dest_md))
+                elif md_file.exists():
+                    md_file.unlink()
+                # Create skill-manifest.json stub if missing
+                sm_path = skill_dir / "skill-manifest.json"
+                if not sm_path.exists():
+                    desc = (
+                        context["agents"].get(stem, "")
+                        or _extract_first_paragraph(dest_md)
+                        or f"{stem} sub-agent"
+                    )
+                    sm_path.write_text(json.dumps({
+                        "name": stem,
+                        "version": "1.0.0",
+                        "description": desc[:200],
+                    }, indent=2))
 
     @classmethod
     def _ensure_adapter_wiring(cls, project_root: str) -> None:

--- a/tests/test_remote_import.py
+++ b/tests/test_remote_import.py
@@ -1,0 +1,215 @@
+"""Tests for remote import helpers: _extract_first_paragraph, _extract_source_context,
+_auto_init_agent_manifest, _auto_stub_skill_manifests."""
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from agent_gen.librarian import (
+    Librarian,
+    _extract_first_paragraph,
+)
+
+
+class TestExtractFirstParagraph(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write(self, name, content):
+        f = self.root / name
+        f.write_text(content)
+        return f
+
+    def test_plain_paragraph(self):
+        f = self._write("doc.md", "First paragraph here.\nStill same paragraph.")
+        result = _extract_first_paragraph(f)
+        self.assertIn("First paragraph", result)
+
+    def test_skips_header(self):
+        f = self._write("doc.md", "# Title\n\nActual description here.")
+        result = _extract_first_paragraph(f)
+        self.assertEqual(result, "Actual description here.")
+
+    def test_skips_frontmatter(self):
+        f = self._write("doc.md", "---\nname: test\nversion: 1.0\n---\n\n# Head\n\nReal content.")
+        result = _extract_first_paragraph(f)
+        self.assertEqual(result, "Real content.")
+
+    def test_stops_at_blank_line(self):
+        f = self._write("doc.md", "First para.\n\nSecond para.")
+        result = _extract_first_paragraph(f)
+        self.assertEqual(result, "First para.")
+
+    def test_empty_file(self):
+        f = self._write("empty.md", "")
+        result = _extract_first_paragraph(f)
+        self.assertEqual(result, "")
+
+    def test_truncates_at_200(self):
+        f = self._write("long.md", "A" * 300)
+        result = _extract_first_paragraph(f)
+        self.assertLessEqual(len(result), 200)
+
+
+class TestExtractSourceContext(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_reads_claude_md_description(self):
+        (self.repo / "CLAUDE.md").write_text("# Project\n\nThis project does RAG for Claude Code.")
+        ctx = Librarian._extract_source_context(str(self.repo))
+        self.assertIn("RAG", ctx["description"])
+
+    def test_reads_claude_agents(self):
+        agents_dir = self.repo / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "qa-writer.md").write_text("# QA Writer\n\nWrites unit tests for the project.")
+        (agents_dir / "security.md").write_text("# Security Auditor\n\nScans for OWASP vulnerabilities.")
+        ctx = Librarian._extract_source_context(str(self.repo))
+        self.assertIn("qa-writer", ctx["agents"])
+        self.assertIn("security", ctx["agents"])
+        self.assertIn("unit tests", ctx["agents"]["qa-writer"])
+        self.assertIn("OWASP", ctx["agents"]["security"])
+
+    def test_empty_repo(self):
+        ctx = Librarian._extract_source_context(str(self.repo))
+        self.assertEqual(ctx["description"], "")
+        self.assertEqual(ctx["agents"], {})
+
+    def test_fallback_to_agents_md(self):
+        (self.repo / "AGENTS.md").write_text("# Agents\n\nThis is the agents manifest.")
+        ctx = Librarian._extract_source_context(str(self.repo))
+        self.assertIn("agents manifest", ctx["description"])
+
+
+class TestAutoInitAgentManifest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.agent_dir = Path(self.tmp.name) / "my-agent"
+        self.agent_dir.mkdir()
+        # Create minimal tracked dirs + one file so sync has something to find
+        (self.agent_dir / "docs").mkdir()
+        (self.agent_dir / "docs" / "CLAUDE.md").write_text("# Agent\n\nDoes stuff.")
+        for d in ["skills", "commands", "scripts", "orchestration"]:
+            (self.agent_dir / d).mkdir()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_creates_manifest_when_missing(self):
+        ctx = {"description": "Local RAG system for Claude Code.", "agents": {}}
+        Librarian._auto_init_agent_manifest(str(self.agent_dir), "my-agent", ctx)
+        manifest_path = self.agent_dir / "agent-manifest.json"
+        self.assertTrue(manifest_path.exists())
+        with open(manifest_path) as f:
+            data = json.load(f)
+        self.assertEqual(data["name"], "my-agent")
+        self.assertEqual(data["description"], "Local RAG system for Claude Code.")
+
+    def test_patches_description_on_existing_manifest(self):
+        # Pre-create manifest with blank description
+        lib = Librarian(str(self.agent_dir))
+        lib.init("my-agent")
+        ctx = {"description": "Patched description.", "agents": {}}
+        Librarian._auto_init_agent_manifest(str(self.agent_dir), "my-agent", ctx)
+        with open(self.agent_dir / "agent-manifest.json") as f:
+            data = json.load(f)
+        self.assertEqual(data["description"], "Patched description.")
+
+    def test_no_description_leaves_existing_unchanged(self):
+        lib = Librarian(str(self.agent_dir))
+        lib.init("my-agent")
+        # Manually set a description
+        manifest = lib._load_manifest()
+        manifest["description"] = "Original."
+        lib._save_manifest(manifest)
+        ctx = {"description": "", "agents": {}}
+        Librarian._auto_init_agent_manifest(str(self.agent_dir), "my-agent", ctx)
+        with open(self.agent_dir / "agent-manifest.json") as f:
+            data = json.load(f)
+        self.assertEqual(data["description"], "Original.")
+
+
+class TestAutoStubSkillManifests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.agent_dir = Path(self.tmp.name) / "agent"
+        self.agent_dir.mkdir()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_promotes_flat_agents_and_creates_stubs(self):
+        agents_dir = self.agent_dir / "orchestration" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "qa-writer.md").write_text("# QA Writer\n\nWrites tests.")
+        (agents_dir / "security.md").write_text("# Security\n\nAudits code.")
+
+        ctx = {
+            "description": "",
+            "agents": {
+                "qa-writer": "Writes comprehensive unit tests.",
+                "security": "Scans for OWASP vulnerabilities.",
+            }
+        }
+        Librarian._auto_stub_skill_manifests(str(self.agent_dir), ctx)
+
+        # Each .md should be promoted to its own subdirectory
+        self.assertTrue((agents_dir / "qa-writer" / "qa-writer.md").exists())
+        self.assertTrue((agents_dir / "security" / "security.md").exists())
+
+        # Each subdirectory should have a skill-manifest.json
+        with open(agents_dir / "qa-writer" / "skill-manifest.json") as f:
+            sm = json.load(f)
+        self.assertEqual(sm["name"], "qa-writer")
+        self.assertIn("unit tests", sm["description"])
+
+        with open(agents_dir / "security" / "skill-manifest.json") as f:
+            sm = json.load(f)
+        self.assertEqual(sm["name"], "security")
+        self.assertIn("OWASP", sm["description"])
+
+    def test_skips_existing_skill_manifest(self):
+        skills_dir = self.agent_dir / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "existing.md").write_text("# Existing\n\nAlready set up.")
+        existing_skill_dir = skills_dir / "existing"
+        existing_skill_dir.mkdir()
+        (existing_skill_dir / "existing.md").write_text("# Existing\n\nAlready set up.")
+        (existing_skill_dir / "skill-manifest.json").write_text(
+            json.dumps({"name": "existing", "version": "2.0.0", "description": "Already here."})
+        )
+
+        ctx = {"description": "", "agents": {}}
+        Librarian._auto_stub_skill_manifests(str(self.agent_dir), ctx)
+
+        # Version should NOT be overwritten
+        with open(existing_skill_dir / "skill-manifest.json") as f:
+            sm = json.load(f)
+        self.assertEqual(sm["version"], "2.0.0")
+
+    def test_falls_back_to_file_content_for_description(self):
+        agents_dir = self.agent_dir / "orchestration" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "documenter.md").write_text("# Documenter\n\nMaintains the devlog automatically.")
+
+        ctx = {"description": "", "agents": {}}  # no pre-extracted description
+        Librarian._auto_stub_skill_manifests(str(self.agent_dir), ctx)
+
+        with open(agents_dir / "documenter" / "skill-manifest.json") as f:
+            sm = json.load(f)
+        self.assertIn("devlog", sm["description"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `--from-git URL` flag to `agent-gen import` enabling one-command import of any git repo as an AgentFactory agent.

**Pipeline:**
```
git clone URL
  → extract_context(README.md, CLAUDE.md, AGENTS.md, .claude/agents/*.md)
  → retrofit (.claude/ layout → standard AgentFactory dirs)
  → auto_stub_skill_manifests() — promote flat sub-agent .md → subdirs + skill-manifest.json
  → auto_init_agent_manifest()  — init + patch description + sync
  → wrap → ZIP → import + audit + register
  → update_harness_files()      — .ai/.CLAUDE.md registry updated with real description
```

**Context extraction:**
- README.md is tried first (most reliable project description source)
- Falls back to CLAUDE.md, AGENTS.md
- Sub-agent descriptions extracted from `.claude/agents/*.md` before retrofit
- HTML comments (`<!-- ... -->`), headers, and YAML frontmatter are all skipped
- Extracted descriptions populate `agent-manifest.json` and each `skill-manifest.json` stub

**Test:**
```bash
agent-gen import --from-git https://github.com/matheusmlopess/implement.ai
agent-gen audit implement.ai   # → CLEAN
```
Result: 4 sub-agents with real descriptions, 6 commands, 4 scripts imported and registered.

## Test plan
- [x] 32 unit tests pass
- [x] `agent-gen import --from-git <url>` end-to-end on implement.ai → CLEAN audit
- [x] `agent-gen import <zip_path>` (existing path) still works
- [x] `.ai/.CLAUDE.md` registry shows real description from README

Closes #35