### PR TITLE
upgrade: git-versioning v1.2.0 → v1.2.1 — enforce gh release create

### DIFF
--- a/.ai/agents/test-agent/skills/git-versioning/SKILL.md
+++ b/.ai/agents/test-agent/skills/git-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-versioning
-version: 1.2.0
+version: 1.2.1
 description: >
   Git and versioning workflow assistant for any project using the versioning template.
   Handles commit, branch, PR, merge, tag, release, rollback, and inspection.
@@ -11,7 +11,7 @@ description: >
   rollback an artifact, or asks "what should I do next" in a git context.
 ---
 
-# Git Versioning Assistant — v1.2.0
+# Git Versioning Assistant — v1.2.1
 
 ---
 
@@ -160,17 +160,27 @@ git branch -d <branch-name>
 
 ### Step 8 — Tag and release (only when DEFAULT_BRANCH is stable)
 
-Determine repo-level bump using the SemVer rules in `repo-state.md`, then:
+Determine repo-level bump using the SemVer rules in `repo-state.md`, then run **all three commands** — tag, push, and release are a single atomic step:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z: <one-line summary>"
 git push origin vX.Y.Z
 gh release create vX.Y.Z \
   --title "vX.Y.Z — <short title>" \
-  --notes "<changelog>"
+  --notes "$(cat <<'EOF'
+## What's new
+- <bullet: what changed>
+- <bullet: what changed>
+
+## Breaking changes
+- <bullet or "None">
+EOF
+)"
 ```
 
-After tagging, update `repo-state.md`:
+**`gh release create` is mandatory — never skip it.** A git tag alone is invisible on GitHub's Releases page. The release notes are what users and collaborators see when they check what changed. If the tag was already pushed without a release, run `gh release create` immediately to backfill it.
+
+After tagging, update `repo-state.md` on a new branch → PR → merge:
 - Add a row to "Current version tags"
 - Update "Latest tag"
 

--- a/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
+++ b/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
@@ -22,8 +22,9 @@ The git-versioning skill reads this to give accurate, repo-specific commands.
 | v2.1.0 | d94ae42 | Librarian intelligence layer enhancements + registry auto-population |
 | v2.1.1 | 91313c3 | Harness cleanup + audit gap detection (version drift, repo-state staleness) |
 | v2.2.0 | c2d5dfc | git-versioning v1.2.0: session branch gate enforcement |
+| v2.3.0 | 076ffcd | agent-gen import --from-git: remote repo import pipeline |
 
-Latest tag: v2.2.0
+Latest tag: v2.3.0
 
 ---
 
@@ -31,7 +32,7 @@ Latest tag: v2.2.0
 
 | Skill | Version | Path |
 |-------|---------|------|
-| git-versioning | v1.2.0 | skills/git-versioning/SKILL.md |
+| git-versioning | v1.2.1 | skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | skills/diff-visualizer/SKILL.md |
 
 ---

--- a/.ai/agents/test-agent/skills/git-versioning/skill-manifest.json
+++ b/.ai/agents/test-agent/skills/git-versioning/skill-manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "git-versioning",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Manages project-wide versioning and repo-state.md updates."
 }

--- a/.ai/skills/git-versioning/SKILL.md
+++ b/.ai/skills/git-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-versioning
-version: 1.2.0
+version: 1.2.1
 description: >
   Git and versioning workflow assistant for any project using the versioning template.
   Handles commit, branch, PR, merge, tag, release, rollback, and inspection.
@@ -11,7 +11,7 @@ description: >
   rollback an artifact, or asks "what should I do next" in a git context.
 ---
 
-# Git Versioning Assistant — v1.2.0
+# Git Versioning Assistant — v1.2.1
 
 ---
 
@@ -160,17 +160,27 @@ git branch -d <branch-name>
 
 ### Step 8 — Tag and release (only when DEFAULT_BRANCH is stable)
 
-Determine repo-level bump using the SemVer rules in `repo-state.md`, then:
+Determine repo-level bump using the SemVer rules in `repo-state.md`, then run **all three commands** — tag, push, and release are a single atomic step:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z: <one-line summary>"
 git push origin vX.Y.Z
 gh release create vX.Y.Z \
   --title "vX.Y.Z — <short title>" \
-  --notes "<changelog>"
+  --notes "$(cat <<'EOF'
+## What's new
+- <bullet: what changed>
+- <bullet: what changed>
+
+## Breaking changes
+- <bullet or "None">
+EOF
+)"
 ```
 
-After tagging, update `repo-state.md`:
+**`gh release create` is mandatory — never skip it.** A git tag alone is invisible on GitHub's Releases page. The release notes are what users and collaborators see when they check what changed. If the tag was already pushed without a release, run `gh release create` immediately to backfill it.
+
+After tagging, update `repo-state.md` on a new branch → PR → merge:
 - Add a row to "Current version tags"
 - Update "Latest tag"
 

--- a/.ai/skills/git-versioning/references/repo-state.md
+++ b/.ai/skills/git-versioning/references/repo-state.md
@@ -22,8 +22,9 @@ The git-versioning skill reads this to give accurate, repo-specific commands.
 | v2.1.0 | da02586 | .ai/ harness consolidation + agent-gen init + complete adapter wiring |
 | v2.1.1 | 91313c3 | Harness cleanup + audit gap detection (version drift, repo-state staleness) |
 | v2.2.0 | c2d5dfc | git-versioning v1.2.0: session branch gate enforcement |
+| v2.3.0 | 076ffcd | agent-gen import --from-git: remote repo import pipeline |
 
-Latest tag: v2.2.0
+Latest tag: v2.3.0
 
 ---
 
@@ -32,7 +33,7 @@ Latest tag: v2.2.0
 | Artifact | Version | Path |
 |----------|---------|------|
 | agent-gen CLI | v0.2.0 | pyproject.toml |
-| git-versioning | v1.2.0 | .ai/skills/git-versioning/SKILL.md |
+| git-versioning | v1.2.1 | .ai/skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | .ai/skills/diff-visualizer/SKILL.md |
 
 ---

--- a/.ai/skills/git-versioning/skill-manifest.json
+++ b/.ai/skills/git-versioning/skill-manifest.json
@@ -1,5 +1,5 @@
 {
   "name": "git-versioning",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Manages project-wide versioning and repo-state.md updates."
 }


### PR DESCRIPTION
Enforces `gh release create` as mandatory in Step 8. A git tag alone is invisible on GitHub Releases. Adds backfill rule for tags pushed without a release.