### PR TITLE
refactor: rename context file .CLAUDE.md → AgentFactory.md

### DIFF
--- a/.ai/AgentFactory.md
+++ b/.ai/AgentFactory.md
@@ -6,7 +6,7 @@ AgentFactory is a lightweight Python-based CLI (`agent-gen`) for building, packa
 
 ## Unified Folder Strategy
 All harness content lives under `.ai/`. The project root is kept clean — only required CLI symlinks are exposed:
-- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CODEX.md` → `.ai/.CLAUDE.md` (this file — single source of truth for all CLIs)
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CODEX.md` → `.ai/AgentFactory.md` (this file — single source of truth for all CLIs)
 - `.claude` → `.ai/adapters/claude` | `.gemini` → `.ai/adapters/gemini` | `.codex` → `.ai/adapters/codex`
 
 Internal layout:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-.ai/.CLAUDE.md
+.ai/AgentFactory.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-.ai/.CLAUDE.md
+.ai/AgentFactory.md

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,1 +1,1 @@
-.ai/.CLAUDE.md
+.ai/AgentFactory.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,1 @@
-.ai/.CLAUDE.md
+.ai/AgentFactory.md

--- a/agent_gen/cli.py
+++ b/agent_gen/cli.py
@@ -110,7 +110,7 @@ def init_project(project_root: str):
     """
     Initialize the AgentFactory harness in a project.
 
-    Creates .ai/ with all harness directories, a single .ai/.CLAUDE.md
+    Creates .ai/ with all harness directories, a single .ai/AgentFactory.md
     source of truth, and wires root symlinks so every CLI tool (Claude,
     Codex, Gemini) reads the same shared context file.
 
@@ -142,7 +142,7 @@ def init_project(project_root: str):
             (d / ".gitkeep").touch()
         click.echo(f"  [ok] {d.relative_to(project_path)}")
 
-    # 2. Create single .CLAUDE.md source of truth
+    # 2. Create single AgentFactory.md source of truth
     context_path = ai_root / CONTEXT_FILE
     if not context_path.exists():
         context_path.write_text(
@@ -173,7 +173,7 @@ def init_project(project_root: str):
     else:
         click.echo(f"  [skip] {global_manifest_path.relative_to(project_path)} (already exists)")
 
-    # 4. Root symlinks — all four .md files point to .ai/.CLAUDE.md
+    # 4. Root symlinks — all four .md files point to .ai/AgentFactory.md
     root_links = {
         "CLAUDE.md":  f"{HARNESS_ROOT}/{CONTEXT_FILE}",
         "AGENTS.md":  f"{HARNESS_ROOT}/{CONTEXT_FILE}",

--- a/agent_gen/librarian.py
+++ b/agent_gen/librarian.py
@@ -11,7 +11,7 @@ from pathlib import Path
 TRACKED_DIRS = ["skills", "commands", "docs", "scripts", "orchestration"]
 MANIFEST_FILE = "agent-manifest.json"
 HARNESS_ROOT = ".ai"
-CONTEXT_FILE = ".CLAUDE.md"  # single source of truth for all CLI instructions
+CONTEXT_FILE = "AgentFactory.md"  # single source of truth for all CLI instructions
 
 
 def _extract_first_paragraph(path: Path) -> str:
@@ -791,7 +791,7 @@ class Librarian:
                 if resolved_path in updated_paths:
                     continue
 
-                # Create .CLAUDE.md stub if missing (first run after init)
+                # Create AgentFactory.md stub if missing (first run after init)
                 if not target_path.exists() and not target_path.is_symlink():
                     if target_name.endswith(CONTEXT_FILE):
                         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -841,7 +841,7 @@ class Librarian:
 
         # Agent-level description: README is the most reliable source for a project
         # description; CLAUDE.md / AGENTS.md often contain instructions, not descriptions.
-        for candidate in ["README.md", "CLAUDE.md", "AGENTS.md", ".ai/.CLAUDE.md"]:
+        for candidate in ["README.md", "CLAUDE.md", "AGENTS.md", ".ai/AgentFactory.md"]:
             f = root / candidate
             if f.exists():
                 desc = _extract_first_paragraph(f)

--- a/tests/test_global_sync.py
+++ b/tests/test_global_sync.py
@@ -41,7 +41,7 @@ class TestGlobalRegistrySync(unittest.TestCase):
             "<!-- @agent-registry:end -->"
         )
 
-        # Root symlink pointing to .ai/.CLAUDE.md (all CLIs share the same file)
+        # Root symlink pointing to .ai/AgentFactory.md (all CLIs share the same file)
         self.root_agents_md = self.project_root / "AGENTS.md"
         os.symlink(self.context_file, self.root_agents_md)
 
@@ -76,7 +76,7 @@ class TestGlobalRegistrySync(unittest.TestCase):
 
     def test_update_harness_files_symlink_awareness(self):
         """update_harness_files respects symlinks and doesn't duplicate content."""
-        # CLAUDE.md at root symlinks to the same .ai/.CLAUDE.md
+        # CLAUDE.md at root symlinks to the same .ai/AgentFactory.md
         claude_md = self.project_root / "CLAUDE.md"
         os.symlink(self.context_file, claude_md)
 


### PR DESCRIPTION
Renames the single source of truth from `.ai/.CLAUDE.md` to `.ai/AgentFactory.md`. All root symlinks (CLAUDE.md, AGENTS.md, GEMINI.md, CODEX.md) rewired. CONTEXT_FILE constant updated. 32 tests pass.