### PR TITLE
chore: rename CLI command agent-gen → agentfactory-gen

### DIFF
--- a/.ai/AgentFactory.md
+++ b/.ai/AgentFactory.md
@@ -4,7 +4,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Overview
-AgentFactory is a lightweight Python-based CLI (`agent-gen`) for building, packaging, and deploying AI agents as **Portable Units**. Source lives in `src/agent_gen/`; tests in `src/tests/`.
+AgentFactory is a lightweight Python-based CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents as **Portable Units**. Source lives in `src/agent_gen/`; tests in `src/tests/`.
 
 ## Development Commands
 

--- a/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
+++ b/.ai/agents/test-agent/skills/git-versioning/references/repo-state.md
@@ -37,7 +37,7 @@ Latest tag: v2.4.2
 
 | Artifact | Version | Path |
 |----------|---------|------|
-| agent-gen CLI | v0.2.0 | pyproject.toml |
+| agentfactory-gen CLI | v0.3.0 | pyproject.toml |
 | git-versioning | v1.3.0 | .ai/skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | .ai/skills/diff-visualizer/SKILL.md |
 

--- a/.ai/rules/milestones.md
+++ b/.ai/rules/milestones.md
@@ -1,7 +1,7 @@
 # Milestones Rule
 <!-- version: 1.0.0 -->
 
-- **Create at init:** Every project must have `.ai/memory/milestones.md` scaffolded by `agent-gen init`. It is the single source of truth for all issue and work-item tracking.
+- **Create at init:** Every project must have `.ai/memory/milestones.md` scaffolded by `agentfactory-gen init`. It is the single source of truth for all issue and work-item tracking.
 - **Update on PR merge:** When a PR closes an issue, move the row from **Pending → Completed** and fill Branch, PR#, short commit SHA, and Tag columns.
 - **Update on release:** When a version tag is cut, stamp the Tag column for all items shipped in that release.
 - **Version marker:** Bump the `<!-- version: X.Y.Z -->` marker (PATCH) on every update to milestones.md.

--- a/.ai/scripts/harness-doctor.sh
+++ b/.ai/scripts/harness-doctor.sh
@@ -63,7 +63,7 @@ file_size() { wc -c < "$1" 2>/dev/null || echo 0; }
 
 check_harness_root() {
   if [[ ! -d "${AI_ROOT}" ]]; then
-    crit "Harness root '${AI_ROOT}/' not found — run 'agent-gen init' first."
+    crit "Harness root '${AI_ROOT}/' not found — run 'agentfactory-gen init' first."
     return
   fi
   ok "Harness root '${AI_ROOT}/' present"

--- a/.ai/skills/git-versioning/references/repo-state.md
+++ b/.ai/skills/git-versioning/references/repo-state.md
@@ -37,7 +37,7 @@ Latest tag: v2.4.2
 
 | Artifact | Version | Path |
 |----------|---------|------|
-| agent-gen CLI | v0.2.0 | pyproject.toml |
+| agentfactory-gen CLI | v0.3.0 | pyproject.toml |
 | git-versioning | v1.3.0 | .ai/skills/git-versioning/SKILL.md |
 | diff-visualizer | v1.1.0 | .ai/skills/diff-visualizer/SKILL.md |
 

--- a/docs/CICD-WORKFLOW.md
+++ b/docs/CICD-WORKFLOW.md
@@ -82,7 +82,7 @@ Each matrix run:
 
 1. **Checks out** the repository
 2. **Installs** the package in editable mode with dev extras: `pip install -e ".[dev]"`  
-   This installs `agent-gen`, `pytest`, `pytest-cov`, and `ruff` as defined in `pyproject.toml`
+   This installs `agentfactory-gen`, `pytest`, `pytest-cov`, and `ruff` as defined in `pyproject.toml`
 3. **Runs the test suite with coverage:**
    ```
    pytest --cov=agent_gen --cov-report=term-missing --cov-fail-under=80

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -10,7 +10,7 @@ Used to start a fresh agent from scratch.
 
 ### ASCII
 \`\`\`text
-[User] ── agent-gen deploy <name> ──▶ [Librarian]
+[User] ── agentfactory-gen deploy <name> ──▶ [Librarian]
                                           │
     ┌─────────────────────────────────────┴─────────────────────────────────────┐
     │                                                                           │
@@ -42,7 +42,7 @@ Used to ingest existing projects from Claude, Gemini, or Codex.
 
 ### ASCII
 \`\`\`text
-[User] ── agent-gen retrofit <path> ──▶ [Librarian]
+[User] ── agentfactory-gen retrofit <path> ──▶ [Librarian]
                                             │
     ┌───────────────────────────────────────┴───────────────────────────────────────┐
     │                                                                               │
@@ -81,7 +81,7 @@ Used to package an agent into a Portable Unit.
 
 ### ASCII
 \`\`\`text
-[User] ── agent-gen wrap <name> ──▶ [Librarian]
+[User] ── agentfactory-gen wrap <name> ──▶ [Librarian]
                                         │
     ┌───────────────────────────────────┴───────────────────────────────────┐
     │                                                                       │
@@ -115,7 +115,7 @@ Used to bring a Portable Unit into a new project.
 
 ### ASCII
 \`\`\`text
-[User] ── agent-gen import <zip> ──▶ [Librarian]
+[User] ── agentfactory-gen import <zip> ──▶ [Librarian]
                                          │
     ┌────────────────────────────────────┴────────────────────────────────────┐
     │                                                                         │
@@ -151,7 +151,7 @@ Used to safely remove an agent.
 
 ### ASCII
 \`\`\`text
-[User] ── agent-gen uninstall <name> ──▶ [Librarian]
+[User] ── agentfactory-gen uninstall <name> ──▶ [Librarian]
                                              │
     ┌────────────────────────────────────────┴────────────────────────────────────────┐
     │                                                                                 │

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -62,11 +62,11 @@ Placed inside `skills/<name>/`. Used to provide metadata about a specific comple
 
 ## 4. Lifecycle Commands
 
-*   `agent-gen deploy <name>`: Scaffolds the structure.
-*   `agent-gen wrap <name>`: Synchronizes, audits, and compresses into a Portable Unit.
-*   `agent-gen import <zip>`: Unpacks and registers the agent in the project.
-*   `agent-gen audit <name>`: Checks for broken paths, missing manifests, or untracked files.
-*   `agent-gen retrofit <path>`: Converts existing Claude/Gemini/Codex structures into AgentFactory.
+*   `agentfactory-gen deploy <name>`: Scaffolds the structure.
+*   `agentfactory-gen wrap <name>`: Synchronizes, audits, and compresses into a Portable Unit.
+*   `agentfactory-gen import <zip>`: Unpacks and registers the agent in the project.
+*   `agentfactory-gen audit <name>`: Checks for broken paths, missing manifests, or untracked files.
+*   `agentfactory-gen retrofit <path>`: Converts existing Claude/Gemini/Codex structures into AgentFactory.
 
 ## 5. Metadata Enforcement
 *   **Orchestration**: The Librarian automatically picks the first file in `orchestration/` if `orchestration_plan` is not set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
-agent-gen = "agent_gen.cli:cli"
+agentfactory-gen = "agent_gen.cli:cli"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
Closes #64

Renames the CLI entry point from `agent-gen` to `agentfactory-gen` to match the PyPI package name.

## Changes
- `pyproject.toml` entry point: `agent-gen` → `agentfactory-gen`
- `.ai/AgentFactory.md`, `harness-doctor.sh`, rules: CLI name updated
- `repo-state.md` (both copies): artifact name + version updated to `agentfactory-gen v0.3.0`
- `docs/CICD-WORKFLOW.md`, `docs/SPEC.md`, `docs/HOWTO.md`: all command references updated

**Internal module `agent_gen` is unchanged** — no Python source renaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)