### PR TITLE
security: fix S6-S8 — supply chain, action SHA pinning, awk injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,10 @@ jobs:
         id: notes
         run: |
           TAG="${{ github.ref_name }}"
+          # Escape special awk regex chars in the tag (#S8)
+          ESCAPED_TAG=$(printf '%s' "$TAG" | sed 's/[[\.*^$(){}?+|]/\\&/g')
           # Extract the section for this tag from CHANGELOG.md
-          NOTES=$(awk "/^## \[${TAG}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          NOTES=$(awk "/^## \[${ESCAPED_TAG}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="See CHANGELOG.md for details."
           fi
@@ -62,7 +64,7 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           body_path: release_notes.txt
           files: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ version = "0.3.0"
 description = "Agent Factory — Librarian-powered agent lifecycle manager"
 requires-python = ">=3.11"
 dependencies = [
-    "click>=8.1",
-    "filelock>=3.13.0",
+    "click>=8.1,<9.0",
+    "filelock>=3.13.0,<4.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Closes #70, #71, #72

| Finding | Severity | Fix |
|---------|----------|-----|
| S6 Supply chain (unbounded deps) | MEDIUM | `click>=8.1,<9.0` and `filelock>=3.13.0,<4.0` |
| S7 Action floating tag | LOW | `softprops/action-gh-release` pinned to commit SHA `3bb12739` |
| S8 awk pattern injection | LOW | `github.ref_name` escaped via `sed` before use in awk pattern |

🤖 Generated with [Claude Code](https://claude.com/claude-code)