### PR TITLE
feat: pre-commit hook for SKILL.md completeness warning (#100)

### DIFF
--- a/.ai/scripts/pre-commit-completeness.sh
+++ b/.ai/scripts/pre-commit-completeness.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# pre-commit-completeness.sh — SKILL.md completeness warning hook
+# <!-- version: 1.0.0 -->
+#
+# Install:
+#   cp .ai/scripts/pre-commit-completeness.sh .git/hooks/pre-commit
+#   chmod +x .git/hooks/pre-commit
+#
+# Bypass:
+#   SKIP_COMPLETENESS_WARN=1 git commit ...
+#
+# The hook warns when a SKILL.md file is staged, prompts to confirm,
+# and prints the CLI command to run the completeness check.
+# Non-interactive environments (CI) detect no TTY and pass through.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Find staged SKILL.md files
+# ---------------------------------------------------------------------------
+SKILL_FILES=$(git diff --cached --name-only 2>/dev/null \
+  | grep -E '^\.ai/skills/.*/SKILL\.md$' || true)
+
+[[ -z "$SKILL_FILES" ]] && exit 0
+
+# ---------------------------------------------------------------------------
+# Already bypassed?
+# ---------------------------------------------------------------------------
+if [[ "${SKIP_COMPLETENESS_WARN:-0}" == "1" ]]; then
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Print warning
+# ---------------------------------------------------------------------------
+echo ""
+echo "  ⚠  SKILL.md staged for commit:"
+while IFS= read -r f; do
+  # Extract skill name from path .ai/skills/<name>/SKILL.md
+  skill_name=$(echo "$f" | sed -E 's|\.ai/skills/([^/]+)/SKILL\.md|\1|')
+  echo "     $f"
+  echo "     → python3 .ai/scripts/skill-completeness-check.py --skill ${skill_name}"
+done <<< "$SKILL_FILES"
+echo ""
+echo "  Running the check ensures the trimmed version preserves all"
+echo "  functional atoms (commands, decision paths, error cases)."
+echo "  Score must be ≥ 90% to pass CI."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Interactive prompt — skip if no TTY (CI, pipes, non-interactive shells)
+# ---------------------------------------------------------------------------
+if [[ ! -t 1 ]] || [[ ! -t 0 ]]; then
+  # Non-interactive: pass through silently
+  exit 0
+fi
+
+read -r -p "  Continue without running completeness check? [y/N] " REPLY
+echo ""
+case "$REPLY" in
+  [yY][eE][sS]|[yY]) exit 0 ;;
+  *) echo "  Commit aborted. Run the check above, then re-commit."; exit 1 ;;
+esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to AgentFactory
+<!-- version: 1.0.0 -->
+
+## Dev Setup
+
+```bash
+git clone https://github.com/matheusmlopess/AgentFactory.git
+cd AgentFactory
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Install Git Hooks
+
+Run this once after cloning — hooks are not tracked by git:
+
+```bash
+cp .ai/scripts/pre-commit-completeness.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+**What the hook does:**
+
+```
+  git commit (with .ai/skills/**/SKILL.md staged)
+      │
+      ▼
+  ⚠  SKILL.md staged — consider running:
+     python3 .ai/scripts/skill-completeness-check.py --skill <name>
+     Continue? [y/N]
+```
+
+Warns when a `SKILL.md` is staged. Interactive prompt in terminal;
+silent pass in CI (no TTY). Bypass any time with:
+
+```bash
+SKIP_COMPLETENESS_WARN=1 git commit ...
+```
+
+## Feature Workflow
+
+Every contribution follows the 8-step lifecycle in `docs/FEATURE-WORKFLOW.md`:
+
+```
+  ① Issue  →  ② Branch  →  ③ Implement  →  ④ CI gates
+  →  ⑤ PR  →  ⑥ Merge  →  ⑦ Milestones  →  ⑧ Priority report
+```
+
+## Running Checks Locally
+
+```bash
+# Harness health
+bash .ai/scripts/harness-doctor.sh
+
+# Skill completeness (requires ANTHROPIC_API_KEY)
+python3 .ai/scripts/skill-completeness-check.py --skill <name>
+
+# Issue priority report
+python3 .ai/scripts/generate-priority-report.py --dry-run
+
+# Tests
+pytest src/tests/ -q
+```


### PR DESCRIPTION
## Summary
- `.ai/scripts/pre-commit-completeness.sh`: installable hook that warns when a `SKILL.md` is staged, prints the completeness check command, and prompts `Continue? [y/N]` in interactive terminals
- Silent pass in CI / non-TTY (no blocking)
- `SKIP_COMPLETENESS_WARN=1` bypass for scripted workflows
- Installed locally: `.git/hooks/pre-commit`
- `CONTRIBUTING.md`: documents hook install + full dev setup

## Test plan
- [x] Hook fires with SKILL.md staged → warning + prompt
- [x] Hook silent when no SKILL.md staged → exit 0
- [x] `SKIP_COMPLETENESS_WARN=1` → exit 0, no output
- [x] Non-TTY (CI) → exit 0, warning printed but no prompt

## Feature Workflow Checklist
- [x] ① Issue #100 existed with no deps → Wave 1
- [x] ② Branch: `feature/100-skill-completeness-precommit`
- [x] ③ Implemented + tested all cases
- [x] ④ harness-doctor passes
- [x] ⑤ PR opened — Closes #100
- [ ] ⑦ milestones.md updated post-merge
- [ ] ⑧ ISSUE-PRIORITY.md regenerated

Closes #100