### PR TITLE
ci: skill completeness dedicated CI job (#101)

### DIFF
--- a/.github/workflows/skill-completeness.yml
+++ b/.github/workflows/skill-completeness.yml
@@ -1,0 +1,52 @@
+name: Skill Completeness
+
+on:
+  push:
+    paths:
+      - ".ai/skills/**/SKILL.md"
+  pull_request:
+    paths:
+      - ".ai/skills/**/SKILL.md"
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: "Skill name to check (overrides matrix)"
+        required: false
+        default: "diff-visualizer"
+
+jobs:
+  completeness:
+    name: Check ${{ matrix.skill }}
+    strategy:
+      matrix:
+        skill: [diff-visualizer, git-versioning]
+      fail-fast: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install --quiet anthropic
+
+      - name: Run completeness check
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python3 .ai/scripts/skill-completeness-check.py \
+            --skill ${{ matrix.skill }} \
+            --threshold 90
+
+      - name: Upload completeness report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: completeness-${{ matrix.skill }}
+          path: .ai/reports/skill-${{ matrix.skill }}-completeness.json
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/skill-completeness.yml` — dedicated CI job triggered only when a `SKILL.md` changes
- Matrix strategy runs one job per skill (`diff-visualizer`, `git-versioning`) with `fail-fast: false` so all skills are checked even if one fails
- `fetch-depth: 2` ensures `git show HEAD~1:...` resolves correctly to pre-change content
- Exit code 1 (score < 90%) blocks the PR; exit 0 passes through
- Artifacts uploaded per-skill: `.ai/reports/skill-<name>-completeness.json`

## CI trigger map

| Event | Path filter | Result |
|-------|-------------|--------|
| `push` / `pull_request` | `.ai/skills/**/SKILL.md` | Runs matrix |
| `workflow_dispatch` | — | Runs matrix (manual override) |
| All other pushes | — | Skipped (zero cost) |

## Test plan

- [ ] Merge and verify workflow appears under Actions → Skill Completeness
- [ ] Trigger manually via `workflow_dispatch` for both skills
- [ ] Confirm artifacts uploaded to run summary

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)