### PR TITLE
feat: webapp completeness report viewer — static, no API key (#104)

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json && vite build",
+    "dev": "node scripts/copy-reports.mjs && vite",
+    "build": "node scripts/copy-reports.mjs && tsc --noEmit -p tsconfig.app.json && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/webapp/scripts/copy-reports.mjs
+++ b/webapp/scripts/copy-reports.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// copy-reports.mjs — copies .ai/reports/*.json into src/data/reports/
+// Run before `vite dev` or `vite build` to embed the latest reports.
+// <!-- version: 1.0.0 -->
+
+import { cpSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = resolve(__dirname, "../../.ai/reports");
+const dest = resolve(__dirname, "../src/data/reports");
+
+mkdirSync(dest, { recursive: true });
+cpSync(src, dest, { recursive: true, filter: (f) => f.endsWith(".json") || f === src });
+
+console.log(`reports: copied ${src} → ${dest}`);

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,5 +1,6 @@
 import { featureCards, lifecycleSteps } from "./data/harness";
 import { HarnessExplorer } from "./components/HarnessExplorer";
+import { CompletenessViewer } from "./components/CompletenessViewer";
 
 function App() {
   return (
@@ -33,6 +34,8 @@ function App() {
       </section>
 
       <HarnessExplorer />
+
+      <CompletenessViewer />
 
       <section className="split">
         <article className="surface">

--- a/webapp/src/components/CompletenessViewer.tsx
+++ b/webapp/src/components/CompletenessViewer.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import type { CompletenessReport, AtomType, AtomStatus } from "../types/completeness";
+import diffReport from "../data/reports/skill-diff-visualizer-completeness.json";
+import gitReport from "../data/reports/skill-git-versioning-completeness.json";
+
+const REPORTS: Record<string, CompletenessReport> = {
+  "diff-visualizer": diffReport as CompletenessReport,
+  "git-versioning": gitReport as CompletenessReport,
+};
+
+const STATUS_ICON: Record<AtomStatus, string> = {
+  preserved: "✓",
+  degraded: "~",
+  missing: "✗",
+};
+
+const TYPE_LABELS: Record<AtomType, string> = {
+  decision_path: "decision path",
+  command: "command",
+  error_case: "error case",
+  data_table: "data table",
+  external_ref: "external ref",
+  constraint: "constraint",
+};
+
+type FilterValue = AtomType | "all";
+
+export function CompletenessViewer() {
+  const skills = Object.keys(REPORTS);
+  const [activeSkill, setActiveSkill] = useState<string>(skills[0]);
+  const [filter, setFilter] = useState<FilterValue>("all");
+
+  const report = REPORTS[activeSkill];
+  const atomTypes = [...new Set(report.atoms.map((a) => a.type))] as AtomType[];
+  const filtered =
+    filter === "all" ? report.atoms : report.atoms.filter((a) => a.type === filter);
+
+  const scoreClass =
+    report.score >= 95 ? "score--high" : report.score >= 90 ? "score--mid" : "score--low";
+
+  const rerunCmd = `python3 .ai/scripts/skill-completeness-check.py --skill ${report.skill}`;
+
+  return (
+    <section className="completeness" id="completeness">
+      <div className="completeness-intro">
+        <span className="badge badge-pro">pro</span>
+        <h2 className="completeness-title">Skill Completeness</h2>
+        <p className="completeness-lede">
+          Pre-generated semantic reports showing how much functional capability each{" "}
+          <code>SKILL.md</code> retained after its last trim. Powered by the two-phase LLM
+          oracle — no API key required to view cached results.
+        </p>
+      </div>
+
+      {/* Skill selector tabs */}
+      <div className="skill-tabs" role="tablist">
+        {skills.map((sk) => (
+          <button
+            key={sk}
+            role="tab"
+            aria-selected={sk === activeSkill}
+            className={`skill-tab${sk === activeSkill ? " skill-tab--active" : ""}`}
+            onClick={() => {
+              setActiveSkill(sk);
+              setFilter("all");
+            }}
+          >
+            {sk}
+          </button>
+        ))}
+      </div>
+
+      {/* Results panel */}
+      <div className="results-panel surface">
+        {/* Score header */}
+        <div className="results-header">
+          <div className={`score-badge ${scoreClass}`}>
+            <span className="score-value">{report.score}%</span>
+            <span className="score-label">{report.passed ? "passed" : "failed"}</span>
+          </div>
+
+          <div className="results-meta">
+            <span className="results-skill">{report.skill}</span>
+            <span className="results-versions">
+              {report.old_version} → {report.new_version}
+            </span>
+            <span className="results-date">
+              {new Date(report.generated_at).toLocaleDateString()}
+            </span>
+          </div>
+
+          <div className="summary-counts">
+            <span className="count count--preserved">
+              <span className="count-icon">✓</span>
+              {report.summary.preserved} preserved
+            </span>
+            {report.summary.degraded > 0 && (
+              <span className="count count--degraded">
+                <span className="count-icon">~</span>
+                {report.summary.degraded} degraded
+              </span>
+            )}
+            {report.summary.missing > 0 && (
+              <span className="count count--missing">
+                <span className="count-icon">✗</span>
+                {report.summary.missing} missing
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Filter bar */}
+        <div className="filter-bar">
+          <button
+            className={`filter-chip${filter === "all" ? " filter-chip--active" : ""}`}
+            onClick={() => setFilter("all")}
+          >
+            all ({report.atoms.length})
+          </button>
+          {atomTypes.map((t) => {
+            const count = report.atoms.filter((a) => a.type === t).length;
+            return (
+              <button
+                key={t}
+                className={`filter-chip${filter === t ? " filter-chip--active" : ""}`}
+                onClick={() => setFilter(t)}
+              >
+                {TYPE_LABELS[t]} ({count})
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Atom list */}
+        <ul className="atom-list">
+          {filtered.map((atom) => (
+            <li key={atom.id} className={`atom-row atom-row--${atom.status}`}>
+              <span className={`atom-status atom-status--${atom.status}`}>
+                {STATUS_ICON[atom.status]}
+              </span>
+              <div className="atom-body">
+                <span className="atom-type">{TYPE_LABELS[atom.type]}</span>
+                <span className="atom-desc">{atom.description}</span>
+                {atom.status !== "preserved" && (
+                  <span className="atom-evidence">{atom.evidence}</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {/* Re-run hint */}
+        <div className="rerun-hint">
+          <span className="rerun-label">Re-run locally:</span>
+          <code className="rerun-cmd">{rerunCmd}</code>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/data/reports/skill-diff-visualizer-completeness.json
+++ b/webapp/src/data/reports/skill-diff-visualizer-completeness.json
@@ -1,0 +1,227 @@
+{
+  "skill": "diff-visualizer",
+  "old_ref": "HEAD",
+  "old_version": "1.1.1",
+  "new_version": "1.1.2",
+  "generated_at": "2026-04-16T11:16:56.180533+00:00",
+  "score": 100,
+  "threshold": 90,
+  "passed": true,
+  "summary": {
+    "preserved": 30,
+    "degraded": 0,
+    "missing": 0
+  },
+  "atoms": [
+    {
+      "id": "version_detection_routing",
+      "type": "decision_path",
+      "description": "Routes to different version-detection logic based on user input: explicit versions, auto-detect, or last two releases.",
+      "status": "preserved",
+      "evidence": "Step 0 table shows all three routing paths: no versions given \u2192 auto-detect, explicit versions \u2192 skip Step 1, and 'last two releases' \u2192 Step 1."
+    },
+    {
+      "id": "auto_detect_commands",
+      "type": "command",
+      "description": "Three git commands to extract most recent and second-most-recent tags for auto-detection: git tag --sort, git describe, and git tag with sed.",
+      "status": "preserved",
+      "evidence": "Step 1 includes all three commands: 'git tag --sort=-version:refname | head -5', 'git describe --tags --abbrev=0', and 'git tag --sort=-version:refname | sed -n '2p''."
+    },
+    {
+      "id": "no_tags_error",
+      "type": "error_case",
+      "description": "When no git tags exist, stop and instruct user to create initial tag with git tag -a command.",
+      "status": "preserved",
+      "evidence": "Step 1 states 'If no tags: stop and show `git tag -a v1.0.0 -m 'Initial release'`.' Error handling table repeats this action."
+    },
+    {
+      "id": "single_tag_fallback",
+      "type": "constraint",
+      "description": "When only one tag exists, use that tag as OLD and HEAD as NEW.",
+      "status": "preserved",
+      "evidence": "Step 1 specifies: 'If one tag: `$OLD` = that tag, `$NEW` = `HEAD`'."
+    },
+    {
+      "id": "repo_diff_commands",
+      "type": "command",
+      "description": "Four git commands to build complete change catalog: git diff with name-status, git diff with stat, and two git ls-tree commands.",
+      "status": "preserved",
+      "evidence": "Step 2 includes all four commands: 'git diff $OLD $NEW --name-status', 'git diff $OLD $NEW --stat', 'git ls-tree --name-only $OLD', and 'git ls-tree --name-only $NEW'."
+    },
+    {
+      "id": "component_taxonomy",
+      "type": "data_table",
+      "description": "Lookup table mapping file path patterns to component keys: skills/, docs/, dashboard/, assets/, and root.",
+      "status": "preserved",
+      "evidence": "Component taxonomy table lists all five mappings: skills/, docs/, dashboard/, assets/, and root with their matching patterns."
+    },
+    {
+      "id": "component_status_rules",
+      "type": "data_table",
+      "description": "Rules for assigning component-level status (NEW, REMOVED, MODIFIED, UNCHANGED) based on file existence and changes.",
+      "status": "preserved",
+      "evidence": "Component-level status explanation provided: NEW (dir didn't exist), REMOVED (gone), MODIFIED (\u22651 file changed), UNCHANGED (no files changed), with root-specific rule."
+    },
+    {
+      "id": "git_status_codes",
+      "type": "data_table",
+      "description": "Maps git status codes (A, M, D, R) to file change types (added, modified, deleted, renamed).",
+      "status": "preserved",
+      "evidence": "Per-file catalog section states: 'Git Status (`A`=NEW, `M`=MODIFIED, `D`=REMOVED, `R`=renamed)'."
+    },
+    {
+      "id": "skill_version_extraction",
+      "type": "command",
+      "description": "Commands to extract version field from SKILL.md front matter: git show for OLD version and head for NEW version.",
+      "status": "preserved",
+      "evidence": "Step 3 specifies both commands: 'git show $OLD:skills/<name>/SKILL.md | head -10' for OLD version and 'head -10 skills/<name>/SKILL.md' for NEW version."
+    },
+    {
+      "id": "missing_version_fallback",
+      "type": "constraint",
+      "description": "When version field is missing from SKILL.md, use 'unknown' in diagrams and tables.",
+      "status": "preserved",
+      "evidence": "Step 3 states: 'No `version:` \u2192 use `\"unknown\"`. Error handling table confirms: 'No `version:` in SKILL.md | Use `\"unknown\"`'."
+    },
+    {
+      "id": "git_show_failure_handling",
+      "type": "error_case",
+      "description": "When git show fails for a skill file, treat skill as NEW regardless of catalog classification.",
+      "status": "preserved",
+      "evidence": "Step 3 notes: 'If `git show $OLD:...` fails, treat skill as NEW.' Error handling table provides identical rule."
+    },
+    {
+      "id": "mermaid_node_id_convention",
+      "type": "constraint",
+      "description": "Node IDs must be camelCase only with no hyphens or spaces; map skill names with hyphens to camelCase equivalents.",
+      "status": "preserved",
+      "evidence": "Node structure section states: 'Node IDs: camelCase, no hyphens (e.g. `sdd-orchestrator` \u2192 `sddOrchestrator`, `docs/` \u2192 `docsNode`)' and formatting rules repeat: 'Node IDs: camelCase, no hyphens, no spaces'."
+    },
+    {
+      "id": "mermaid_node_label_format",
+      "type": "constraint",
+      "description": "Node labels must use double quotes and newline character \\n for line breaks.",
+      "status": "preserved",
+      "evidence": "Node structure section specifies: 'Node labels: `\"Label\\n(details)\"` \u2014 skill nodes: `\"sdd-orchestrator\\nv2.0.0\"`, component nodes: `\"docs/\\n3 files changed\"'."
+    },
+    {
+      "id": "status_color_mapping",
+      "type": "data_table",
+      "description": "Color scheme for Mermaid nodes by status: UNCHANGED (blue-gray), MODIFIED (amber), NEW (green), REMOVED (red) with fill, stroke, and text colors.",
+      "status": "preserved",
+      "evidence": "Style colors table provides all four status rows with fill, stroke, and color values: UNCHANGED (#1e293b/#60a5fa/#e2e8f0), MODIFIED (#1c1507/#f59e0b/#fef3c7), NEW (#052e16/#22c55e/#dcfce7), REMOVED (#1c0707/#f87171/#fee2e2)."
+    },
+    {
+      "id": "old_diagram_rules",
+      "type": "constraint",
+      "description": "OLD diagram includes only components/skills existing at OLD version; excludes NEW items; marks REMOVED items with REMOVED color.",
+      "status": "preserved",
+      "evidence": "OLD diagram section states: 'Include all components/skills that existed at `$OLD`. Exclude NEW items. Mark REMOVED items with REMOVED color'."
+    },
+    {
+      "id": "new_diagram_rules",
+      "type": "constraint",
+      "description": "NEW diagram includes all components at current state; applies color per component/skill status; separates standalone skills into subgraph.",
+      "status": "preserved",
+      "evidence": "NEW diagram section specifies: 'Include ALL components at current state. Apply color per status. Standalone skills go in a separate subgraph'."
+    },
+    {
+      "id": "mermaid_formatting_rules",
+      "type": "constraint",
+      "description": "Mermaid formatting requirements: camelCase IDs, double-quoted labels, individual style statements (no classDef), wrap in pre.mermaid tags in HTML.",
+      "status": "preserved",
+      "evidence": "Mermaid formatting rules section lists all requirements: camelCase IDs, double-quoted labels, individual style statements (no classDef), and wrap in `<pre class=\"mermaid\">` with escaped `<`/`>` characters."
+    },
+    {
+      "id": "placeholder_variables",
+      "type": "data_table",
+      "description": "All template placeholders with their sources: OLD_VERSION, NEW_VERSION, GENERATED_DATE, OLD_DIAGRAM, NEW_DIAGRAM, skill counts, step counts, and file change counts.",
+      "status": "preserved",
+      "evidence": "Step 5 placeholder table documents all variables with sources: OLD_VERSION, NEW_VERSION, GENERATED_DATE, diagram placeholders, skill/step counts, file change counts, and UNCHANGED_COUNT."
+    },
+    {
+      "id": "change_table_structure",
+      "type": "data_table",
+      "description": "HTML table row format for changed files: component group headers, file name, badge status, version columns, and notes; sorted by component.",
+      "status": "preserved",
+      "evidence": "Step 5 change table specification describes row format: path | badge status | version columns | notes, with component group headers and badge classes (badge-new, badge-modified, badge-removed)."
+    },
+    {
+      "id": "change_table_grouping",
+      "type": "constraint",
+      "description": "Change table rows must be grouped by component in order: skills/, docs/, dashboard/, assets/, root files; with group-header separator rows.",
+      "status": "preserved",
+      "evidence": "Step 5 states: 'Sort: `skills/` \u2192 `docs/` \u2192 `dashboard/` \u2192 `assets/` \u2192 root. Add `<tr class=\"group-header\">` before each group'."
+    },
+    {
+      "id": "badge_class_mapping",
+      "type": "data_table",
+      "description": "Badge CSS classes by git status: badge-new (A), badge-modified (M), badge-removed (D).",
+      "status": "preserved",
+      "evidence": "Change table section specifies: 'Badge class: `badge-new` (A) | `badge-modified` (M) | `badge-removed` (D)'."
+    },
+    {
+      "id": "version_column_rules",
+      "type": "constraint",
+      "description": "Version columns populate only for skill SKILL.md files; all other files use '\u2014' as placeholder.",
+      "status": "preserved",
+      "evidence": "Change table section states: 'Version columns only for SKILL.md files; others use `<span class=\"na\">\u2014</span>`'."
+    },
+    {
+      "id": "output_filename_format",
+      "type": "constraint",
+      "description": "Output HTML file path: assets/diff-VERSION1-to-VERSION2.html; use HEAD if NEW is HEAD.",
+      "status": "preserved",
+      "evidence": "Step 6 specifies: 'Write to: `assets/diff-$OLD-to-$NEW.html` (HEAD variant: `assets/diff-vX.Y.Z-to-HEAD.html`)'."
+    },
+    {
+      "id": "html_template_dependency",
+      "type": "external_ref",
+      "description": "Requires template file at references/html-template.md; must be read and placeholders replaced before writing output.",
+      "status": "preserved",
+      "evidence": "Step 6 requires: 'Read template from `references/html-template.md`'. References section confirms: 'HTML template: `references/html-template.md`'."
+    },
+    {
+      "id": "self_contained_html_constraint",
+      "type": "constraint",
+      "description": "HTML file must be self-contained with no local file references; only CDN links allowed.",
+      "status": "preserved",
+      "evidence": "Step 6 states: 'Self-contained \u2014 CDN links only, no local file references'."
+    },
+    {
+      "id": "template_missing_error",
+      "type": "error_case",
+      "description": "When template file is missing, stop and report error with expected path.",
+      "status": "preserved",
+      "evidence": "Error handling table states: 'Template missing | Stop. Report path and suggest reinstalling skill'."
+    },
+    {
+      "id": "no_changes_error",
+      "type": "error_case",
+      "description": "When no files differ between versions, report and stop.",
+      "status": "preserved",
+      "evidence": "Error handling table specifies: 'No files changed | Report: \"No differences found between $OLD and $NEW.\"'."
+    },
+    {
+      "id": "mermaid_size_limit",
+      "type": "constraint",
+      "description": "When Mermaid text exceeds ~4000 characters, split into two sub-diagrams stacked vertically.",
+      "status": "preserved",
+      "evidence": "Error handling table includes: 'Mermaid text > ~4000 chars | Split into two sub-diagrams stacked vertically'."
+    },
+    {
+      "id": "placeholder_verification",
+      "type": "constraint",
+      "description": "Before writing file, verify no remaining {{...}} tokens and no unescaped <> characters in node labels.",
+      "status": "preserved",
+      "evidence": "Step 6 includes verification: 'Verify no remaining `{{...}}` tokens'."
+    },
+    {
+      "id": "report_format",
+      "type": "data_table",
+      "description": "User-facing report structure: file path, change summary counts, component status list, and optional next steps.",
+      "status": "preserved",
+      "evidence": "Step 7 provides user report structure: 'Report output path, change summary (added/modified/removed counts per component), and that it opens in any browser without a server.'"
+    }
+  ]
+}

--- a/webapp/src/data/reports/skill-git-versioning-completeness.json
+++ b/webapp/src/data/reports/skill-git-versioning-completeness.json
@@ -1,0 +1,332 @@
+{
+  "skill": "git-versioning",
+  "old_ref": "HEAD",
+  "old_version": "1.3.0",
+  "new_version": "1.3.1",
+  "generated_at": "2026-04-16T11:17:39.883540+00:00",
+  "score": 98,
+  "threshold": 90,
+  "passed": true,
+  "summary": {
+    "preserved": 44,
+    "degraded": 0,
+    "missing": 1
+  },
+  "atoms": [
+    {
+      "id": "load_repo_state",
+      "type": "external_ref",
+      "description": "Read project context from skills/git-versioning/references/repo-state.md for REMOTE_URL, DEFAULT_BRANCH, LATEST_TAG, and ARTIFACT_VERSIONS.",
+      "status": "preserved",
+      "evidence": "Step 0 reads `skills/git-versioning/references/repo-state.md` for REMOTE_URL, DEFAULT_BRANCH, LATEST_TAG, and ARTIFACT_VERSIONS"
+    },
+    {
+      "id": "check_milestones",
+      "type": "external_ref",
+      "description": "Optionally read .ai/memory/milestones.md Pending table to confirm branch name and scope when user asks what to do next.",
+      "status": "preserved",
+      "evidence": "Step 0 mentions 'Also check `.ai/memory/milestones.md` (if it exists) \u2014 the **Pending** table shows open issues'"
+    },
+    {
+      "id": "session_branch_gate",
+      "type": "constraint",
+      "description": "Never allow edits directly on DEFAULT_BRANCH; enforce branch creation or stashing before any modifications.",
+      "status": "preserved",
+      "evidence": "Step 0.5 'Never skip this gate. Direct commits to `DEFAULT_BRANCH` are always wrong.'"
+    },
+    {
+      "id": "gate_decision_table",
+      "type": "decision_path",
+      "description": "Route behavior based on four states: DEFAULT_BRANCH clean, DEFAULT_BRANCH dirty, non-default clean, non-default dirty.",
+      "status": "preserved",
+      "evidence": "Step 0.5 contains state table: clean/dirty \u00d7 DEFAULT_BRANCH/non-default with corresponding actions"
+    },
+    {
+      "id": "workflow_selector",
+      "type": "decision_path",
+      "description": "Route user intent (commit, upgrade, rollback, tag, merge, PR, inspect, or next-step) to correct workflow part.",
+      "status": "preserved",
+      "evidence": "Step 1 routes user intent (commit, upgrade, rollback, tag, merge, PR, inspect, next-step) to correct workflow"
+    },
+    {
+      "id": "branch_naming_rules",
+      "type": "data_table",
+      "description": "Branch name templates: upgrade/<artifact-name>-vX.Y.Z, feature/<description>, docs/<topic>, fix/<description>.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 2: 'Branch name rules: `upgrade/<artifact>-vX.Y.Z` | `feature/<desc>` | `docs/<topic>` | `fix/<desc>`'"
+    },
+    {
+      "id": "commit_message_types",
+      "type": "data_table",
+      "description": "Commit type values: upgrade, feature, docs, fix, chore with required format <type>: <summary> \u2014 <impact>.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 3: 'Types: `upgrade` | `feature` | `docs` | `fix` | `chore`. Always stage specific files'"
+    },
+    {
+      "id": "git_checkout_default",
+      "type": "command",
+      "description": "Execute 'git checkout DEFAULT_BRANCH' to switch to default branch (value from repo-state.md).",
+      "status": "preserved",
+      "evidence": "Part 1 Step 1: '`git checkout DEFAULT_BRANCH`' command shown"
+    },
+    {
+      "id": "git_pull",
+      "type": "command",
+      "description": "Execute 'git pull' to sync local default branch with remote.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 1: '`git pull`' command shown"
+    },
+    {
+      "id": "git_branch_current",
+      "type": "command",
+      "description": "Execute 'git branch --show-current' to check current branch at session start.",
+      "status": "preserved",
+      "evidence": "Step 0.5: '`git branch --show-current`' command shown"
+    },
+    {
+      "id": "git_status_check",
+      "type": "command",
+      "description": "Execute 'git status --short' to detect uncommitted changes at session start.",
+      "status": "preserved",
+      "evidence": "Step 0.5: '`git status --short`' command shown"
+    },
+    {
+      "id": "git_create_branch",
+      "type": "command",
+      "description": "Execute 'git checkout -b <branch-name>' with user-suggested name following naming rules.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 2: '`git checkout -b <branch-name>`' command shown"
+    },
+    {
+      "id": "git_stage_specific",
+      "type": "constraint",
+      "description": "Always stage specific files via 'git add <files>' \u2014 never use 'git add .' or 'git add -A'.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 3: 'Always stage specific files \u2014 never `git add .` or `git add -A`'"
+    },
+    {
+      "id": "git_commit",
+      "type": "command",
+      "description": "Execute 'git commit -m' with message format <type>: <summary> \u2014 <impact>.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 3: '`git commit -m \"<type>: <summary> \u2014 <impact>\"`'"
+    },
+    {
+      "id": "git_push_branch",
+      "type": "command",
+      "description": "Execute 'git push -u origin <branch-name>' to push feature branch.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 4: '`git push -u origin <branch-name>`'"
+    },
+    {
+      "id": "pre_commit_hook",
+      "type": "external_ref",
+      "description": "Pre-commit hook (.claude/hooks/pre-commit-check.sh) blocks commits if staged .md files lack version markers.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 3: 'Pre-commit hook (`.claude/hooks/pre-commit-check.sh`) blocks commits if staged `.md` files lack version markers'"
+    },
+    {
+      "id": "issue_writer_handoff",
+      "type": "decision_path",
+      "description": "If issue-writer skill installed, delegate PR body generation; otherwise create PR directly via gh cli.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 5: 'If **issue-writer** skill is installed, delegate PR body generation'"
+    },
+    {
+      "id": "gh_pr_create",
+      "type": "command",
+      "description": "Execute 'gh pr create' with title and body format including Summary and Test plan sections.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 5: '`gh pr create` with title and body format including Summary and Test plan sections'"
+    },
+    {
+      "id": "gh_pr_merge",
+      "type": "command",
+      "description": "Execute 'gh pr merge <number> --merge' to merge PR via GitHub CLI.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 6: '`gh pr merge <number> --merge`'"
+    },
+    {
+      "id": "git_cleanup_branch",
+      "type": "command",
+      "description": "Execute 'git checkout DEFAULT_BRANCH && git pull && git branch -d <branch-name>' after merge.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 7: '`git checkout DEFAULT_BRANCH && git pull && git branch -d <branch-name>`'"
+    },
+    {
+      "id": "integration_test_gate",
+      "type": "constraint",
+      "description": "Run full integration test suite before tagging; do not tag if tests fail.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: 'Run integration tests first: `pytest -m integration -v --no-cov`. If any fail, do not tag.'"
+    },
+    {
+      "id": "pytest_integration",
+      "type": "command",
+      "description": "Execute 'pytest -m integration -v --no-cov' to validate repo state before release.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: '`pytest -m integration -v --no-cov`' command shown"
+    },
+    {
+      "id": "semver_rules",
+      "type": "external_ref",
+      "description": "Apply SemVer bump rules from repo-state.md to determine vX.Y.Z increment.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: 'Determine SemVer bump from `repo-state.md`'"
+    },
+    {
+      "id": "git_tag",
+      "type": "command",
+      "description": "Execute 'git tag -a vX.Y.Z -m' with annotated tag and message vX.Y.Z: <summary>.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: '`git tag -a vX.Y.Z -m \"vX.Y.Z: <one-line summary>\"`'"
+    },
+    {
+      "id": "git_push_tag",
+      "type": "command",
+      "description": "Execute 'git push origin vX.Y.Z' to push tag to remote.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: '`git push origin vX.Y.Z`'"
+    },
+    {
+      "id": "gh_release_create",
+      "type": "constraint",
+      "description": "Never skip 'gh release create' \u2014 it is mandatory to make tag visible on GitHub Releases page.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: '**`gh release create` is mandatory \u2014 never skip it.**'"
+    },
+    {
+      "id": "gh_release_command",
+      "type": "command",
+      "description": "Execute 'gh release create vX.Y.Z' with title and notes including What's new and Breaking changes sections.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: '`gh release create vX.Y.Z --title --notes` with What's new and Breaking changes sections'"
+    },
+    {
+      "id": "update_repo_state",
+      "type": "command",
+      "description": "After tag, update repo-state.md Current version tags row and Latest tag on new PR branch \u2192 merge.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: 'After tagging, update `repo-state.md` (new branch \u2192 PR \u2192 merge): add tag row, update \"Latest tag\"'"
+    },
+    {
+      "id": "milestones_update",
+      "type": "constraint",
+      "description": "After every merged PR or release, update .ai/memory/milestones.md \u2014 move issues Pending \u2192 Completed with branch, PR#, commit SHA, version tag.",
+      "status": "preserved",
+      "evidence": "Step 8.5: 'Move closed issues from **Pending \u2192 Completed**; fill Branch, PR#, commit SHA, tag' and 'Never skip this step'"
+    },
+    {
+      "id": "milestones_version_bump",
+      "type": "command",
+      "description": "Bump <!-- version: X.Y.Z --> marker on milestones.md with PATCH version and commit alongside release docs.",
+      "status": "preserved",
+      "evidence": "Step 8.5: 'Bump `<!-- version: X.Y.Z -->` on `milestones.md` (PATCH bump)'"
+    },
+    {
+      "id": "devlog_update",
+      "type": "external_ref",
+      "description": "Invoke project-documenter agent to log release to docs/DEVLOG.md \u2014 never write DEVLOG manually.",
+      "status": "missing",
+      "evidence": "No reference to invoking project-documenter agent or updating DEVLOG.md found in trimmed version"
+    },
+    {
+      "id": "artifact_upgrade_checklist",
+      "type": "constraint",
+      "description": "Before artifact upgrade: verify dependencies, interfaces, references, bump scope, CLAUDE.md, repo-state.md, optional docs.",
+      "status": "preserved",
+      "evidence": "Part 2 Pre-upgrade checklist covers dependencies, interfaces, references, bump scope, CLAUDE.md, repo-state.md"
+    },
+    {
+      "id": "version_enforcer_invocation",
+      "type": "external_ref",
+      "description": "Run version-enforcer skill to apply version bump, scan unversioned files, update CLAUDE.md and repo-state.md.",
+      "status": "preserved",
+      "evidence": "Part 2 Upgrade steps: 'run version-enforcer skill' and Part 1 Step 3 mentions 'Fix with version-enforcer skill'"
+    },
+    {
+      "id": "artifact_reinstall_gate",
+      "type": "constraint",
+      "description": "After artifact upgrade merge, re-install skill in Claude.ai project \u2014 git workflow complete does not mean Claude has new version loaded.",
+      "status": "preserved",
+      "evidence": "Part 2: 'Re-install in Claude.ai \u2192 Project \u2192 Skills \u2190 DO NOT SKIP' and Part 3 Step 2: 'Re-install in Claude (Part 2)'"
+    },
+    {
+      "id": "git_show_artifact_history",
+      "type": "command",
+      "description": "Execute 'git log --oneline skills/<artifact-name>/SKILL.md' to find version history for rollback.",
+      "status": "preserved",
+      "evidence": "Part 3: '`git log --oneline skills/<artifact-name>/SKILL.md`'"
+    },
+    {
+      "id": "git_restore_artifact",
+      "type": "command",
+      "description": "Execute 'git show <tag-or-hash>:skills/<artifact-name>/SKILL.md > skills/<artifact-name>/SKILL.md' to restore artifact at specific tag.",
+      "status": "preserved",
+      "evidence": "Part 3: '`git show <tag-or-hash>:skills/<artifact-name>/SKILL.md > skills/<artifact-name>/SKILL.md`'"
+    },
+    {
+      "id": "rollback_merge_gate",
+      "type": "constraint",
+      "description": "After artifact rollback, PR \u2192 merge and re-install in Claude; no new tag needed for rollback.",
+      "status": "preserved",
+      "evidence": "Part 3: 'Commit forward \u2192 PR \u2192 merge (Part 1 Steps 3\u20137) then Re-install in Claude'"
+    },
+    {
+      "id": "inspection_commands",
+      "type": "data_table",
+      "description": "Available inspection commands: git tag, git show, git log, git diff, git checkout, gh pr list, gh release view, scan-versions.sh.",
+      "status": "preserved",
+      "evidence": "Part 4 lists all inspection commands: git tag, git log, git diff, gh pr list, gh release view, scan-versions.sh"
+    },
+    {
+      "id": "state_assessment_steps",
+      "type": "decision_path",
+      "description": "For 'what should I do next': infer uncommitted changes, branch location, open PRs, tag status; output exact next command.",
+      "status": "preserved",
+      "evidence": "Part 5: 'Check: uncommitted changes? feature branch or DEFAULT_BRANCH? open PRs? current DEFAULT_BRANCH tagged? Output the exact next command'"
+    },
+    {
+      "id": "smoke_test_plan",
+      "type": "data_table",
+      "description": "Post-upgrade smoke tests: standard trigger, edge/boundary trigger, negative test; rollback if any fails.",
+      "status": "preserved",
+      "evidence": "Part 5: 'send three prompts: a standard trigger, an edge/boundary case, and a non-trigger. If any fails: rollback'"
+    },
+    {
+      "id": "repo_state_unfilled_error",
+      "type": "error_case",
+      "description": "If repo-state.md has unfilled placeholders, stop and ask user to fill Remote section before continuing.",
+      "status": "preserved",
+      "evidence": "Step 0: 'If `repo-state.md` has unfilled placeholders, stop' with exact message to output"
+    },
+    {
+      "id": "default_branch_direct_edit_error",
+      "type": "error_case",
+      "description": "If on DEFAULT_BRANCH with clean working tree, stop and instruct user to create branch before proceeding.",
+      "status": "preserved",
+      "evidence": "Step 0.5: 'On `DEFAULT_BRANCH`, clean | **STOP.** Output branch creation command. Do not proceed.'"
+    },
+    {
+      "id": "default_branch_dirty_error",
+      "type": "error_case",
+      "description": "If on DEFAULT_BRANCH with uncommitted changes, emergency stop and instruct stash \u2192 branch \u2192 pop workflow.",
+      "status": "preserved",
+      "evidence": "Step 0.5: 'On `DEFAULT_BRANCH`, dirty | **EMERGENCY STOP.** Output stash + branch + pop commands'"
+    },
+    {
+      "id": "integration_test_failure_error",
+      "type": "error_case",
+      "description": "If integration tests fail before tag, do not tag; fix underlying behavior first and push fix commit.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 8: 'If any fail, do not tag' with instruction to fix behavior first"
+    },
+    {
+      "id": "pre_commit_version_marker_error",
+      "type": "error_case",
+      "description": "If pre-commit hook detects missing version markers in staged .md files, fix with version-enforcer skill and re-stage.",
+      "status": "preserved",
+      "evidence": "Part 1 Step 3: 'Fix with version-enforcer skill, then re-stage and retry'"
+    }
+  ]
+}

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -330,6 +330,285 @@ code {
 
 /* ── end Harness Explorer ─────────────────────────── */
 
+/* ── Completeness Viewer ──────────────────────────── */
+
+.badge-pro {
+  background: rgba(206, 137, 34, 0.18);
+  color: #7a4f00;
+}
+
+@media (prefers-color-scheme: dark) {
+  .badge-pro { color: #f5c76a; }
+}
+
+.completeness {
+  margin-top: 1.25rem;
+}
+
+.completeness-intro {
+  margin-bottom: 1rem;
+}
+
+.completeness-title {
+  font-family: var(--ce-font-display);
+  font-size: 1.5rem;
+  margin: 0.5rem 0 0.4rem;
+}
+
+.completeness-lede {
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+/* skill tabs */
+
+.skill-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.skill-tab {
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: var(--ce-surface);
+  color: var(--ce-text-soft);
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.skill-tab:hover {
+  background: var(--ce-surface-strong);
+  color: var(--ce-text);
+}
+
+.skill-tab--active {
+  background: var(--ce-accent);
+  color: #fffdf8;
+  border-color: transparent;
+}
+
+/* results panel */
+
+.results-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.results-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+/* score badge */
+
+.score-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 5rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 16px;
+  line-height: 1;
+}
+
+.score--high { background: rgba(86, 211, 199, 0.18); }
+.score--mid  { background: rgba(206, 137, 34, 0.18); }
+.score--low  { background: rgba(220, 60, 60, 0.18); }
+
+.score-value {
+  font-family: var(--ce-font-display);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--ce-text);
+}
+
+.score-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ce-text-soft);
+  margin-top: 0.2rem;
+}
+
+.results-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  justify-content: center;
+}
+
+.results-skill {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ce-text);
+}
+
+.results-versions,
+.results-date {
+  font-size: 0.8rem;
+  color: var(--ce-text-soft);
+}
+
+.summary-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-left: auto;
+}
+
+.count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+}
+
+.count-icon { font-size: 0.72rem; }
+
+.count--preserved { background: rgba(86, 211, 199, 0.15); color: var(--ce-accent-strong); }
+.count--degraded  { background: rgba(206, 137, 34, 0.15); color: #7a4f00; }
+.count--missing   { background: rgba(220, 60, 60, 0.12);  color: #9b2020; }
+
+@media (prefers-color-scheme: dark) {
+  .count--degraded { color: #f5c76a; }
+  .count--missing  { color: #ff9090; }
+}
+
+/* filter bar */
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.filter-chip {
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: transparent;
+  color: var(--ce-text-soft);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.filter-chip:hover {
+  background: var(--ce-surface-strong);
+  color: var(--ce-text);
+}
+
+.filter-chip--active {
+  background: var(--ce-surface-strong);
+  color: var(--ce-text);
+  border-color: var(--ce-accent);
+}
+
+/* atom list */
+
+.atom-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.atom-row {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--ce-border);
+}
+
+.atom-row:last-child {
+  border-bottom: none;
+}
+
+.atom-status {
+  font-size: 0.85rem;
+  width: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.atom-status--preserved { color: var(--ce-accent); }
+.atom-status--degraded  { color: #ce8922; }
+.atom-status--missing   { color: #c03030; }
+
+@media (prefers-color-scheme: dark) {
+  .atom-status--degraded { color: #f5c76a; }
+  .atom-status--missing  { color: #ff8080; }
+}
+
+.atom-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.atom-type {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ce-accent-strong);
+}
+
+.atom-desc {
+  font-size: 0.85rem;
+  color: var(--ce-text);
+  line-height: 1.45;
+}
+
+.atom-evidence {
+  font-size: 0.78rem;
+  color: var(--ce-text-soft);
+  font-style: italic;
+}
+
+/* re-run hint */
+
+.rerun-hint {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--ce-border);
+}
+
+.rerun-label {
+  font-size: 0.78rem;
+  color: var(--ce-text-soft);
+  white-space: nowrap;
+}
+
+.rerun-cmd {
+  font-size: 0.78rem;
+  color: var(--ce-accent-strong);
+  background: var(--ce-surface-strong);
+  padding: 0.25rem 0.6rem;
+  border-radius: 6px;
+  word-break: break-all;
+}
+
+/* ── end Completeness Viewer ──────────────────────── */
+
 @media (max-width: 900px) {
   .panel-grid,
   .split {

--- a/webapp/src/types/completeness.ts
+++ b/webapp/src/types/completeness.ts
@@ -1,0 +1,37 @@
+// completeness.ts — types for skill completeness JSON reports
+// <!-- version: 1.0.0 -->
+
+export type AtomType =
+  | "decision_path"
+  | "command"
+  | "error_case"
+  | "data_table"
+  | "external_ref"
+  | "constraint";
+
+export type AtomStatus = "preserved" | "degraded" | "missing";
+
+export interface Atom {
+  id: string;
+  type: AtomType;
+  description: string;
+  status: AtomStatus;
+  evidence: string;
+}
+
+export interface CompletenessReport {
+  skill: string;
+  old_ref: string;
+  old_version: string;
+  new_version: string;
+  generated_at: string;
+  score: number;
+  threshold: number;
+  passed: boolean;
+  summary: {
+    preserved: number;
+    degraded: number;
+    missing: number;
+  };
+  atoms: Atom[];
+}


### PR DESCRIPTION
## Summary

- New `CompletenessViewer` component renders pre-generated `.ai/reports/*.json` at build time
- `webapp/src/types/completeness.ts` — `CompletenessReport`, `Atom`, `AtomType`, `AtomStatus`
- `webapp/scripts/copy-reports.mjs` — copies `.ai/reports/*.json` → `src/data/reports/` before `dev`/`build`
- SkillSelector tabs per skill, score badge (green ≥95% / amber ≥90% / red <90%), summary counts, filterable atom list by type, re-run CLI hint
- `badge-pro` amber style added matching the design token palette
- `npm run build` passes TypeScript strict check

## Acceptance criteria coverage

- [x] `webapp/src/types/completeness.ts` defines all required types
- [x] `webapp/scripts/copy-reports.mjs` wired into `dev` and `build`
- [x] SkillSelector shows all skills with cached reports
- [x] ResultsPanel renders score, summary counts, atom rows with status icons
- [x] Atom list filterable by type
- [x] `badge-pro` CSS style added
- [x] `npm run build` passes TypeScript check

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)