### PR TITLE
feat: completeness gate in adapter-add command (#102)

### DIFF
--- a/src/agent_gen/cli.py
+++ b/src/agent_gen/cli.py
@@ -735,7 +735,19 @@ def adapter_group():
     show_default=True,
     help="Root of the project to activate the adapter in.",
 )
-def adapter_add(name: str, project_root: str):
+@click.option(
+    "--check-completeness",
+    is_flag=True,
+    default=False,
+    help="After compiling, run skill-completeness-check.py on over-budget skills (requires ANTHROPIC_API_KEY).",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="With --check-completeness: exit non-zero if any skill scores below the adapter threshold.",
+)
+def adapter_add(name: str, project_root: str, check_completeness: bool, strict: bool):
     """
     Activate a CLI adapter mid-project.
 
@@ -820,6 +832,111 @@ def adapter_add(name: str, project_root: str):
         _echo(f"  [linked] {folder_symlink} -> {folder_target}")
 
     _echo(f"\n[librarian] Adapter '{name}' activated.")
+
+    # 7. Completeness gate — check skill sizes against adapter budget
+    _adapter_completeness_gate(
+        name=name,
+        config=config,
+        project_path=project_path,
+        ai_root=ai_root,
+        check_completeness=check_completeness,
+        strict=strict,
+    )
+
+
+def _adapter_completeness_gate(
+    name: str,
+    config: dict,
+    project_path: Path,
+    ai_root: Path,
+    check_completeness: bool,
+    strict: bool,
+) -> None:
+    """Warn when skill files exceed the adapter's character budget.
+
+    With check_completeness=True, also runs skill-completeness-check.py on
+    each over-budget skill (requires ANTHROPIC_API_KEY).  With strict=True,
+    exits non-zero if any skill scores below the adapter threshold.
+    """
+    import subprocess
+    import sys
+
+    skills_dir = ai_root / "skills"
+    if not skills_dir.exists():
+        return
+
+    char_limit: int = config.get("skill_char_limit", 18_000)
+    threshold: int = config.get("completeness_threshold", 90)
+    reports_dir = ai_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    over_budget: list[tuple[str, int]] = []
+    for skill_dir in sorted(skills_dir.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        size = skill_md.stat().st_size
+        if size > char_limit:
+            over_budget.append((skill_dir.name, size))
+
+    if not over_budget:
+        _echo(f"  [ok] all skills within {char_limit:,} byte limit for '{name}'")
+        return
+
+    _echo(f"\n  ⚠  {len(over_budget)} skill(s) exceed the '{name}' adapter limit ({char_limit:,} bytes):")
+    for skill_name, size in over_budget:
+        excess = size - char_limit
+        _echo(f"     {skill_name}: {size:,} bytes (+{excess:,} over budget)")
+        _echo(f"     → python3 .ai/scripts/skill-completeness-check.py --skill {skill_name} --threshold {threshold}")
+
+    if not check_completeness:
+        _echo("\n  Tip: re-run with --check-completeness to score each skill automatically.")
+        return
+
+    # Run completeness check for each over-budget skill
+    import os
+
+    check_script = project_path / ".ai" / "scripts" / "skill-completeness-check.py"
+    if not check_script.exists():
+        _echo(f"\n  ⚠  completeness script not found: {check_script}")
+        return
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        _echo("\n  ⚠  --check-completeness requires ANTHROPIC_API_KEY to be set.")
+        return
+
+    _echo("\n  Running completeness checks …")
+    any_failed = False
+    for skill_name, _ in over_budget:
+        report_path = reports_dir / f"skill-{skill_name}-{name}-completeness.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(check_script),
+                "--skill", skill_name,
+                "--threshold", str(threshold),
+                "--out", str(report_path),
+                "--quiet",
+            ],
+            cwd=str(project_path),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            _echo(f"  [pass] {skill_name}")
+        elif result.returncode == 1:
+            _echo(f"  [warn] {skill_name} — score below {threshold}%")
+            if strict:
+                any_failed = True
+        else:
+            _echo(f"  [error] {skill_name} — {result.stderr.strip()[:120]}")
+
+    _echo(f"\n  Reports saved to {reports_dir.relative_to(project_path)}/")
+    if any_failed and strict:
+        raise click.ClickException(
+            f"One or more skills scored below the {threshold}% threshold for '{name}'. "
+            "Trim the skill(s) and re-run, or use --no-strict to treat as warning."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_gen/librarian.py
+++ b/src/agent_gen/librarian.py
@@ -148,6 +148,10 @@ _FORMAT_REGISTRY: dict[str, dict] = {
             "rules": "_fmt_rules_list",
         },
         "section_order": ["skills", "commands", "agents", "rules"],
+        # Per-skill character budget (bytes). Warn if SKILL.md exceeds this.
+        "skill_char_limit": 18_000,
+        # Completeness score threshold (0–100) for --check-completeness.
+        "completeness_threshold": 90,
     },
     "codex": {
         "output": "brief.md",
@@ -169,6 +173,9 @@ _FORMAT_REGISTRY: dict[str, dict] = {
             "rules": "_fmt_rules_list",
         },
         "section_order": ["skills", "agents", "rules"],
+        # Codex has a tighter context window — stricter per-skill budget.
+        "skill_char_limit": 10_000,
+        "completeness_threshold": 95,
     },
     "gemini": {
         "output": "brief.md",
@@ -189,6 +196,8 @@ _FORMAT_REGISTRY: dict[str, dict] = {
             "rules": "_fmt_rules_list",
         },
         "section_order": ["skills", "agents", "rules"],
+        "skill_char_limit": 18_000,
+        "completeness_threshold": 90,
     },
 }
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -491,6 +491,48 @@ class TestCliCommands(unittest.TestCase):
             self.assertFalse(os.path.islink("AGENTS.md"))
             self.assertIn("Custom content", Path("AGENTS.md").read_text())
 
+    def test_adapter_add_ok_message_when_skills_within_budget(self):
+        """adapter add prints ok message when no skills exceed the adapter's char limit."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            result = self.runner.invoke(cli, ["adapter", "add", "codex"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            # No skills are imported yet — all-clear message should appear
+            self.assertIn("ok", result.output.lower())
+
+    def test_adapter_add_warns_when_skill_over_budget(self):
+        """adapter add emits a warning when a SKILL.md exceeds the adapter's char limit."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            # Create a skill that exceeds the codex char limit (10,000 bytes)
+            skill_dir = Path(f"{HARNESS_ROOT}/skills/big-skill")
+            skill_dir.mkdir(parents=True)
+            oversized = "x" * 11_000
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: big-skill\ndescription: test\n---\n{oversized}\n"
+            )
+            result = self.runner.invoke(cli, ["adapter", "add", "codex"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("exceed", result.output)
+            self.assertIn("big-skill", result.output)
+
+    def test_adapter_add_check_completeness_missing_script_warns(self):
+        """--check-completeness when script is absent prints a warning and exits 0."""
+        with self.runner.isolated_filesystem():
+            # init without creating the completeness script
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            skill_dir = Path(f"{HARNESS_ROOT}/skills/big-skill")
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: big-skill\ndescription: test\n---\n" + "x" * 11_000
+            )
+            result = self.runner.invoke(
+                cli, ["adapter", "add", "codex", "--check-completeness"]
+            )
+            self.assertEqual(result.exit_code, 0, result.output)
+            # Script is not present in isolated filesystem → script-not-found warning
+            self.assertIn("completeness script not found", result.output)
+
     def test_brief_cmd_regenerates_all(self):
         """brief command updates AgentFactory.md and all active adapter briefs."""
         with self.runner.isolated_filesystem():


### PR DESCRIPTION
## Summary

- Adds `skill_char_limit` and `completeness_threshold` to each adapter in `_FORMAT_REGISTRY` — claude: 18k/90%, codex: 10k/95%, gemini: 18k/90%
- `adapter-add` now checks every SKILL.md against the adapter's byte budget after brief compilation; warns with excess bytes and the exact CLI command to fix
- New `--check-completeness` flag invokes `skill-completeness-check.py` per over-budget skill (requires `ANTHROPIC_API_KEY`)
- New `--strict` flag makes threshold failures exit non-zero (blocking)
- Reports saved to `.ai/reports/skill-<name>-<adapter>-completeness.json`
- 3 new tests covering: ok path (no over-budget skills), warning path (skill over budget), missing-script path for `--check-completeness`
- 174/174 tests pass

## Example output

```
agentfactory-gen adapter add codex

  ⚠  1 skill(s) exceed the 'codex' adapter limit (10,000 bytes):
     diff-visualizer: 11,042 bytes (+1,042 over budget)
     → python3 .ai/scripts/skill-completeness-check.py --skill diff-visualizer --threshold 95

  Tip: re-run with --check-completeness to score each skill automatically.
```

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)