### PR TITLE
feat: per-adapter completeness thresholds from config (#103)

### DIFF
--- a/.ai/config/completeness.json
+++ b/.ai/config/completeness.json
@@ -1,0 +1,10 @@
+{
+  "completeness": {
+    "thresholds": {
+      "claude":  90,
+      "codex":   95,
+      "gemini":  90
+    },
+    "default": 90
+  }
+}

--- a/.ai/scripts/harness-doctor.sh
+++ b/.ai/scripts/harness-doctor.sh
@@ -172,7 +172,7 @@ check_skills_completeness() {
     local out="${AI_ROOT}/reports/skill-${name}-completeness.json"
     local stderr_out rc score reason
     stderr_out=$(python3 "${AI_ROOT}/scripts/skill-completeness-check.py" \
-        --skill "${name}" --threshold 90 --out "${out}" --quiet 2>&1) && rc=0 || rc=$?
+        --skill "${name}" --adapter claude --out "${out}" --quiet 2>&1) && rc=0 || rc=$?
     score=$(python3 -c "import json; d=json.load(open('${out}')); print(d['score'])" 2>/dev/null || echo "?")
     if [[ $rc -eq 0 ]]; then
       ok "Skill completeness: ${name} (${score}%)"

--- a/.ai/scripts/skill-completeness-check.py
+++ b/.ai/scripts/skill-completeness-check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # skill-completeness-check.py — Semantic completeness checker for SKILL.md files
-# <!-- version: 1.0.0 -->
+# <!-- version: 1.1.0 -->
 #
 # Usage:
 #   python3 .ai/scripts/skill-completeness-check.py --skill <name> [options]
@@ -10,7 +10,14 @@
 #   --old <git-ref>    Git ref for original (default: HEAD)
 #   --new <path>       Path to trimmed version (default: .ai/skills/<name>/SKILL.md)
 #   --out <path>       JSON report path (default: .ai/reports/skill-<name>-completeness.json)
-#   --threshold <int>  Minimum completeness % to exit 0 (default: 90)
+#   --threshold <int>  Minimum completeness % to exit 0 (explicit override; skips config lookup)
+#   --adapter <name>   Adapter name — selects threshold from .ai/config/completeness.json
+#
+# Threshold resolution order:
+#   1. Explicit --threshold value
+#   2. --adapter name looked up in .ai/config/completeness.json
+#   3. "default" key in .ai/config/completeness.json
+#   4. Hardcoded fallback: 90
 #
 # Requires:
 #   - ANTHROPIC_API_KEY environment variable
@@ -23,8 +30,30 @@ import os
 import subprocess
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 
 import anthropic
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+_CONFIG_PATH = ".ai/config/completeness.json"
+_DEFAULT_THRESHOLD = 90
+
+
+def load_threshold(adapter: str | None, config_path: str = _CONFIG_PATH) -> int:
+    """Return threshold for adapter from config file, or the global default."""
+    try:
+        with open(config_path) as fh:
+            data = json.load(fh)
+        block = data.get("completeness", {})
+        if adapter:
+            return int(block.get("thresholds", {}).get(adapter, block.get("default", _DEFAULT_THRESHOLD)))
+        return int(block.get("default", _DEFAULT_THRESHOLD))
+    except (FileNotFoundError, KeyError, ValueError, json.JSONDecodeError):
+        return _DEFAULT_THRESHOLD
 
 # ---------------------------------------------------------------------------
 # ANSI colour helpers
@@ -248,7 +277,10 @@ def main() -> int:
     parser.add_argument("--old",       default="HEAD",  help="Git ref for original (default: HEAD)")
     parser.add_argument("--new",       default=None,    help="Path to trimmed version")
     parser.add_argument("--out",       default=None,    help="JSON report output path")
-    parser.add_argument("--threshold", type=int, default=90, help="Min % to exit 0 (default: 90)")
+    parser.add_argument("--threshold", type=int, default=None,
+                        help="Explicit min %% to exit 0 (overrides config/adapter lookup)")
+    parser.add_argument("--adapter",   default=None,
+                        help="Adapter name — selects threshold from .ai/config/completeness.json")
     parser.add_argument("--quiet", action="store_true", help="Suppress terminal output (JSON report still written)")
     args = parser.parse_args()
 
@@ -256,8 +288,13 @@ def main() -> int:
     old_ref      = args.old
     new_path     = args.new or f".ai/skills/{skill_name}/SKILL.md"
     out_path     = args.out or f".ai/reports/skill-{skill_name}-completeness.json"
-    threshold    = args.threshold
     skill_git    = f".ai/skills/{skill_name}/SKILL.md"
+
+    # Threshold resolution: explicit → adapter config → config default → 90
+    if args.threshold is not None:
+        threshold = args.threshold
+    else:
+        threshold = load_threshold(args.adapter)
 
     global _QUIET
     _QUIET = args.quiet

--- a/.github/workflows/skill-completeness.yml
+++ b/.github/workflows/skill-completeness.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           python3 .ai/scripts/skill-completeness-check.py \
             --skill ${{ matrix.skill }} \
-            --threshold 90
+            --adapter claude
 
       - name: Upload completeness report
         if: always()

--- a/src/agent_gen/cli.py
+++ b/src/agent_gen/cli.py
@@ -844,6 +844,23 @@ def adapter_add(name: str, project_root: str, check_completeness: bool, strict: 
     )
 
 
+def _load_completeness_threshold(adapter: str, ai_root: Path) -> int:
+    """Read per-adapter threshold from .ai/config/completeness.json.
+
+    Resolution order: adapter-specific → default key → 90.
+    Falls back to 90 on any read/parse error.
+    """
+    import json as _json
+
+    config_path = ai_root / "config" / "completeness.json"
+    try:
+        data = _json.loads(config_path.read_text(encoding="utf-8"))
+        block = data.get("completeness", {})
+        return int(block.get("thresholds", {}).get(adapter, block.get("default", 90)))
+    except (FileNotFoundError, KeyError, ValueError, _json.JSONDecodeError):
+        return 90
+
+
 def _adapter_completeness_gate(
     name: str,
     config: dict,
@@ -866,7 +883,8 @@ def _adapter_completeness_gate(
         return
 
     char_limit: int = config.get("skill_char_limit", 18_000)
-    threshold: int = config.get("completeness_threshold", 90)
+    # Config file takes precedence over FORMAT_REGISTRY default
+    threshold: int = _load_completeness_threshold(name, ai_root)
     reports_dir = ai_root / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -533,6 +533,43 @@ class TestCliCommands(unittest.TestCase):
             # Script is not present in isolated filesystem → script-not-found warning
             self.assertIn("completeness script not found", result.output)
 
+    def test_adapter_add_reads_threshold_from_config(self):
+        """adapter-add uses per-adapter threshold from .ai/config/completeness.json."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            # Write a completeness config with a tight codex threshold
+            config_dir = Path(f"{HARNESS_ROOT}/config")
+            config_dir.mkdir(parents=True)
+            (config_dir / "completeness.json").write_text(
+                '{"completeness": {"thresholds": {"codex": 99}, "default": 80}}'
+            )
+            # Over-budget skill for codex (10k limit)
+            skill_dir = Path(f"{HARNESS_ROOT}/skills/big-skill")
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("---\nname: big-skill\ndescription: t\n---\n" + "x" * 11_000)
+            result = self.runner.invoke(cli, ["adapter", "add", "codex"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            # The warning should mention threshold 99
+            self.assertIn("99", result.output)
+
+    def test_adapter_add_falls_back_to_default_threshold(self):
+        """adapter-add uses 'default' threshold when adapter is not listed in config."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            config_dir = Path(f"{HARNESS_ROOT}/config")
+            config_dir.mkdir(parents=True)
+            # No 'claude' key — should fall back to default 85
+            (config_dir / "completeness.json").write_text(
+                '{"completeness": {"thresholds": {}, "default": 85}}'
+            )
+            skill_dir = Path(f"{HARNESS_ROOT}/skills/big-skill")
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("---\nname: big-skill\ndescription: t\n---\n" + "x" * 19_000)
+            result = self.runner.invoke(cli, ["adapter", "add", "claude"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            # Falls back to default 85 from config
+            self.assertIn("85", result.output)
+
     def test_brief_cmd_regenerates_all(self):
         """brief command updates AgentFactory.md and all active adapter briefs."""
         with self.runner.isolated_filesystem():


### PR DESCRIPTION
## Summary

- New `.ai/config/completeness.json` — single source of truth for per-adapter thresholds (claude: 90%, codex: 95%, gemini: 90%)
- `skill-completeness-check.py` gains `--adapter <name>` flag; threshold resolution: explicit `--threshold` → `--adapter` config → config `default` → 90
- `adapter-add` gate reads threshold via `_load_completeness_threshold()` from config file instead of FORMAT_REGISTRY hardcoded values
- `harness-doctor.sh` updated to pass `--adapter claude` (drops hardcoded `--threshold 90`)
- `skill-completeness.yml` CI workflow updated to use `--adapter claude`
- 2 new tests: config lookup by adapter name, fallback to config default
- 176/176 tests pass

## Config schema

```json
{
  "completeness": {
    "thresholds": {
      "claude":  90,
      "codex":   95,
      "gemini":  90
    },
    "default": 90
  }
}
```

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)