### PR TITLE
feat: public agent registry browse UI — static scaffold (#81)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,6 +1,7 @@
 import { featureCards, lifecycleSteps } from "./data/harness";
 import { HarnessExplorer } from "./components/HarnessExplorer";
 import { CompletenessViewer } from "./components/CompletenessViewer";
+import { RegistryBrowser } from "./components/RegistryBrowser";
 
 function App() {
   return (
@@ -36,6 +37,8 @@ function App() {
       <HarnessExplorer />
 
       <CompletenessViewer />
+
+      <RegistryBrowser />
 
       <section className="split">
         <article className="surface">

--- a/webapp/src/components/RegistryBrowser.tsx
+++ b/webapp/src/components/RegistryBrowser.tsx
@@ -1,0 +1,201 @@
+import { useState, useMemo } from "react";
+import { REGISTRY_AGENTS } from "../data/registry";
+import type { AgentListing } from "../types/registry";
+
+function formatDownloads(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function AgentCard({
+  agent,
+  selected,
+  onClick,
+}: {
+  agent: AgentListing;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={`reg-card${selected ? " reg-card--selected" : ""}`}
+      onClick={onClick}
+    >
+      <div className="reg-card-header">
+        <span className="reg-card-slug">{agent.slug}</span>
+        <span className="reg-card-version">v{agent.version}</span>
+      </div>
+      <p className="reg-card-desc">{agent.description}</p>
+      <div className="reg-card-footer">
+        <span className="reg-card-author">@{agent.author}</span>
+        <span className="reg-card-downloads">
+          ↓ {formatDownloads(agent.downloads)}
+        </span>
+      </div>
+      <div className="reg-card-tags">
+        {agent.tags.slice(0, 4).map((t) => (
+          <span key={t} className="reg-tag">{t}</span>
+        ))}
+      </div>
+    </button>
+  );
+}
+
+function DetailPane({ agent }: { agent: AgentListing }) {
+  const installCmd = `agentfactory-gen import --from-registry ${agent.slug}`;
+  const [copied, setCopied] = useState(false);
+
+  function copy() {
+    navigator.clipboard.writeText(installCmd).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    });
+  }
+
+  return (
+    <div className="reg-detail">
+      <div className="reg-detail-header">
+        <div className="reg-detail-title-row">
+          <h3 className="reg-detail-slug">{agent.slug}</h3>
+          <span className="reg-detail-version">v{agent.version}</span>
+        </div>
+        <p className="reg-detail-meta">
+          by <strong>@{agent.author}</strong> · published {formatDate(agent.published_at)} · {agent.downloads.toLocaleString()} downloads
+        </p>
+      </div>
+
+      <p className="reg-detail-desc">{agent.description}</p>
+
+      <div className="reg-detail-tags">
+        {agent.tags.map((t) => (
+          <span key={t} className="reg-tag">{t}</span>
+        ))}
+      </div>
+
+      {/* Install command */}
+      <div className="reg-install">
+        <span className="reg-install-label">Install</span>
+        <div className="reg-install-row">
+          <code className="reg-install-cmd">{installCmd}</code>
+          <button className="reg-copy-btn" onClick={copy}>
+            {copied ? "copied ✓" : "copy"}
+          </button>
+        </div>
+      </div>
+
+      {/* Manifest preview */}
+      <div className="reg-manifest">
+        <p className="reg-manifest-label">Manifest</p>
+        <div className="reg-manifest-grid">
+          {agent.manifest.skills.length > 0 && (
+            <div className="reg-manifest-row">
+              <span className="reg-manifest-key">skills</span>
+              <span className="reg-manifest-val">
+                {agent.manifest.skills.join(", ")}
+              </span>
+            </div>
+          )}
+          {agent.manifest.commands.length > 0 && (
+            <div className="reg-manifest-row">
+              <span className="reg-manifest-key">commands</span>
+              <span className="reg-manifest-val">
+                {agent.manifest.commands.join(", ")}
+              </span>
+            </div>
+          )}
+          {agent.manifest.adapters.length > 0 && (
+            <div className="reg-manifest-row">
+              <span className="reg-manifest-key">adapters</span>
+              <span className="reg-manifest-val">
+                {agent.manifest.adapters.join(", ")}
+              </span>
+            </div>
+          )}
+          <div className="reg-manifest-row">
+            <span className="reg-manifest-key">version</span>
+            <span className="reg-manifest-val">{agent.manifest.version}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RegistryBrowser() {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<AgentListing>(REGISTRY_AGENTS[0]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return REGISTRY_AGENTS;
+    return REGISTRY_AGENTS.filter(
+      (a) =>
+        a.slug.includes(q) ||
+        a.description.toLowerCase().includes(q) ||
+        a.tags.some((t) => t.includes(q)) ||
+        a.author.toLowerCase().includes(q)
+    );
+  }, [query]);
+
+  return (
+    <section className="registry" id="registry">
+      <div className="registry-intro">
+        <h2 className="registry-title">Agent Registry</h2>
+        <p className="registry-lede">
+          Browse and import Portable Unit agent bundles published by the community.
+          Install any agent with a single CLI command.
+        </p>
+      </div>
+
+      {/* Search bar */}
+      <div className="reg-search-row">
+        <input
+          className="reg-search"
+          type="search"
+          placeholder="Search agents by name, tag, or author…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <span className="reg-count">
+          {filtered.length} agent{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Two-panel layout */}
+      <div className="reg-panels surface">
+        {/* Card list */}
+        <div className="reg-list">
+          {filtered.length === 0 ? (
+            <p className="reg-empty">No agents match "{query}"</p>
+          ) : (
+            filtered.map((agent) => (
+              <AgentCard
+                key={agent.slug}
+                agent={agent}
+                selected={agent.slug === selected?.slug}
+                onClick={() => setSelected(agent)}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Detail pane */}
+        <div className="reg-detail-wrap">
+          {selected ? (
+            <DetailPane agent={selected} />
+          ) : (
+            <p className="reg-empty">Select an agent to see details.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/data/registry.ts
+++ b/webapp/src/data/registry.ts
@@ -1,0 +1,108 @@
+// registry.ts — mock agent listing data (Phase 1 static scaffold)
+// Replace with API calls once backend (FastAPI + PostgreSQL) is deployed.
+// <!-- version: 1.0.0 -->
+
+import type { AgentListing } from "../types/registry";
+
+export const REGISTRY_AGENTS: AgentListing[] = [
+  {
+    slug: "git-workflow-agent",
+    version: "2.3.0",
+    description:
+      "Full git workflow automation: feature branching, semantic versioning, PR management, and changelog generation. Wraps the git-versioning skill with opinionated defaults.",
+    author: "matheusmlopess",
+    downloads: 1_284,
+    published_at: "2026-03-12T09:14:00Z",
+    tags: ["git", "versioning", "workflow", "ci"],
+    is_public: true,
+    zip_url: "#",
+    manifest: {
+      name: "git-workflow-agent",
+      version: "2.3.0",
+      description: "Git workflow automation with semantic versioning and PR management.",
+      skills: ["git-versioning", "diff-visualizer"],
+      commands: ["git-workflow"],
+      adapters: ["claude", "codex"],
+    },
+  },
+  {
+    slug: "code-reviewer",
+    version: "1.1.2",
+    description:
+      "Structured code review agent. Analyses diffs, checks for security patterns, enforces style guides, and produces a scored review report. Works with GitHub PRs via the gh CLI.",
+    author: "af-community",
+    downloads: 876,
+    published_at: "2026-03-28T14:30:00Z",
+    tags: ["code-review", "security", "github", "pr"],
+    is_public: true,
+    zip_url: "#",
+    manifest: {
+      name: "code-reviewer",
+      version: "1.1.2",
+      description: "Structured PR code review with security and style checks.",
+      skills: ["diff-visualizer"],
+      commands: ["review-pr"],
+      adapters: ["claude", "gemini"],
+    },
+  },
+  {
+    slug: "docs-writer",
+    version: "1.0.0",
+    description:
+      "Documentation generation agent. Reads source code and existing docs, identifies gaps, and produces markdown documentation with consistent structure and version markers.",
+    author: "af-community",
+    downloads: 542,
+    published_at: "2026-04-01T11:05:00Z",
+    tags: ["docs", "markdown", "writing"],
+    is_public: true,
+    zip_url: "#",
+    manifest: {
+      name: "docs-writer",
+      version: "1.0.0",
+      description: "Automated documentation generation from source code and existing docs.",
+      skills: [],
+      commands: ["write-docs"],
+      adapters: ["claude"],
+    },
+  },
+  {
+    slug: "test-scaffold",
+    version: "1.2.1",
+    description:
+      "Unit and integration test scaffolding agent. Analyses existing code, identifies untested paths, and generates pytest / Jest test skeletons with 80% coverage targets.",
+    author: "af-community",
+    downloads: 391,
+    published_at: "2026-04-05T08:22:00Z",
+    tags: ["testing", "pytest", "jest", "coverage"],
+    is_public: true,
+    zip_url: "#",
+    manifest: {
+      name: "test-scaffold",
+      version: "1.2.1",
+      description: "Test skeleton generation targeting 80% coverage.",
+      skills: [],
+      commands: ["scaffold-tests"],
+      adapters: ["claude", "codex", "gemini"],
+    },
+  },
+  {
+    slug: "deploy-agent",
+    version: "0.9.0",
+    description:
+      "Deployment pipeline agent for Railway, Render, and Fly.io. Reads project structure, generates platform configs, and guides through first-deploy and rollback procedures.",
+    author: "matheusmlopess",
+    downloads: 218,
+    published_at: "2026-04-10T16:45:00Z",
+    tags: ["deploy", "railway", "render", "infra"],
+    is_public: true,
+    zip_url: "#",
+    manifest: {
+      name: "deploy-agent",
+      version: "0.9.0",
+      description: "Deployment automation for Railway, Render, and Fly.io.",
+      skills: [],
+      commands: ["deploy"],
+      adapters: ["claude"],
+    },
+  },
+];

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -634,3 +634,345 @@ code {
     max-height: 240px;
   }
 }
+
+/* ── Registry Browser ─────────────────────────────── */
+
+.registry {
+  margin-top: 1.25rem;
+}
+
+.registry-intro {
+  margin-bottom: 1rem;
+}
+
+.registry-title {
+  font-family: var(--ce-font-display);
+  font-size: 1.5rem;
+  margin: 0 0 0.4rem;
+}
+
+.registry-lede {
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+/* search bar */
+
+.reg-search-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.reg-search {
+  flex: 1;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--ce-border);
+  border-radius: 999px;
+  background: var(--ce-surface);
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  font-size: 0.88rem;
+  outline: none;
+  transition: border-color 0.12s;
+}
+
+.reg-search:focus {
+  border-color: var(--ce-accent);
+}
+
+.reg-count {
+  font-size: 0.78rem;
+  color: var(--ce-text-soft);
+  white-space: nowrap;
+}
+
+/* two-panel layout */
+
+.reg-panels {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.reg-list {
+  border-right: 1px solid var(--ce-border);
+  overflow-y: auto;
+  max-height: 560px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* agent card */
+
+.reg-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  width: 100%;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--ce-border);
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  text-align: left;
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  transition: background 0.1s;
+}
+
+.reg-card:last-child {
+  border-bottom: none;
+}
+
+.reg-card:hover {
+  background: var(--ce-surface-strong);
+}
+
+.reg-card--selected {
+  background: var(--ce-surface-strong);
+  border-left: 2px solid var(--ce-accent);
+}
+
+.reg-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.reg-card-slug {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ce-text);
+}
+
+.reg-card--selected .reg-card-slug {
+  color: var(--ce-accent-strong);
+}
+
+.reg-card-version {
+  font-size: 0.72rem;
+  color: var(--ce-text-soft);
+  flex-shrink: 0;
+}
+
+.reg-card-desc {
+  font-size: 0.8rem;
+  color: var(--ce-text-soft);
+  line-height: 1.4;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.reg-card-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: var(--ce-text-soft);
+}
+
+.reg-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.15rem;
+}
+
+.reg-tag {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: var(--ce-surface-strong);
+  color: var(--ce-text-soft);
+  border: 1px solid var(--ce-border);
+}
+
+/* detail pane */
+
+.reg-detail-wrap {
+  overflow-y: auto;
+  max-height: 560px;
+}
+
+.reg-detail {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reg-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.reg-detail-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.reg-detail-slug {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 1.25rem;
+  margin: 0;
+  color: var(--ce-text);
+}
+
+.reg-detail-version {
+  font-size: 0.82rem;
+  color: var(--ce-text-soft);
+}
+
+.reg-detail-meta {
+  font-size: 0.8rem;
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+.reg-detail-desc {
+  font-size: 0.9rem;
+  line-height: 1.65;
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+.reg-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+/* install command */
+
+.reg-install {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.reg-install-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ce-accent-strong);
+}
+
+.reg-install-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 10px;
+  padding: 0.55rem 0.8rem;
+}
+
+.reg-install-cmd {
+  flex: 1;
+  font-size: 0.82rem;
+  color: var(--ce-accent-strong);
+  word-break: break-all;
+}
+
+.reg-copy-btn {
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: var(--ce-surface);
+  color: var(--ce-text-soft);
+  font-size: 0.75rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s, color 0.1s;
+  flex-shrink: 0;
+}
+
+.reg-copy-btn:hover {
+  background: var(--ce-accent);
+  color: #fffdf8;
+  border-color: transparent;
+}
+
+/* manifest preview */
+
+.reg-manifest {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reg-manifest-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ce-accent-strong);
+  margin: 0;
+}
+
+.reg-manifest-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+}
+
+.reg-manifest-row {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.82rem;
+}
+
+.reg-manifest-key {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  color: var(--ce-text-soft);
+  min-width: 5rem;
+  flex-shrink: 0;
+}
+
+.reg-manifest-val {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  color: var(--ce-text);
+}
+
+/* empty state */
+
+.reg-empty {
+  padding: 2rem 1.5rem;
+  color: var(--ce-text-soft);
+  font-size: 0.88rem;
+  font-style: italic;
+}
+
+/* responsive */
+
+@media (max-width: 900px) {
+  .reg-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .reg-list {
+    border-right: none;
+    border-bottom: 1px solid var(--ce-border);
+    max-height: 280px;
+  }
+
+  .reg-detail-wrap {
+    max-height: none;
+  }
+}
+
+/* ── end Registry Browser ─────────────────────────── */

--- a/webapp/src/types/registry.ts
+++ b/webapp/src/types/registry.ts
@@ -1,0 +1,24 @@
+// registry.ts — types for the public agent registry
+// <!-- version: 1.0.0 -->
+
+export interface AgentListing {
+  slug: string;
+  version: string;
+  description: string;
+  author: string;
+  downloads: number;
+  published_at: string; // ISO 8601
+  tags: string[];
+  is_public: boolean;
+  manifest: AgentManifestPreview;
+  zip_url: string;
+}
+
+export interface AgentManifestPreview {
+  name: string;
+  version: string;
+  description: string;
+  skills: string[];
+  commands: string[];
+  adapters: string[];
+}


### PR DESCRIPTION
## Summary

- New `RegistryBrowser` component: search bar + two-panel layout (card list + detail pane)
- `AgentListing` TypeScript type defines the contract for the future FastAPI backend
- 5 mock agents seeded in `src/data/registry.ts` (real data replaces on backend deploy)
- Detail pane: description, tags, install command with clipboard copy, manifest preview (skills / commands / adapters / version)
- Client-side search filters by slug, description, tags, and author in real time
- Responsive: collapses to single column below 900px
- `npm run build` passes — TypeScript strict + Vite bundle (13.5 kB CSS, 244 kB JS)

## What this is NOT (tracked separately)

- Backend: FastAPI + PostgreSQL + Cloudflare R2 — separate infra issue
- `agentfactory-gen import --from-registry` CLI extension — tracked in #82
- ZIP upload / publish flow — requires auth (#83)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)