### PR TITLE
feat: lifecycle stepper + manifest inspector UI components (#80)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,7 +1,9 @@
-import { featureCards, lifecycleSteps } from "./data/harness";
+import { featureCards } from "./data/harness";
 import { HarnessExplorer } from "./components/HarnessExplorer";
 import { CompletenessViewer } from "./components/CompletenessViewer";
 import { RegistryBrowser } from "./components/RegistryBrowser";
+import { LifecycleStepper } from "./components/LifecycleStepper";
+import { ManifestInspector } from "./components/ManifestInspector";
 
 function App() {
   return (
@@ -40,32 +42,9 @@ function App() {
 
       <RegistryBrowser />
 
-      <section className="split">
-        <article className="surface">
-          <p className="section-label">Phase 1 foundation</p>
-          <h2>What this scaffold already provides</h2>
-          <ul className="checklist">
-            <li>React 19 + TypeScript strict-mode baseline</li>
-            <li>CSS variable design tokens for light and dark themes</li>
-            <li>Static data module for issue-driven UI work</li>
-            <li>GitHub Pages deployment workflow on release tags</li>
-          </ul>
-        </article>
+      <LifecycleStepper />
 
-        <article className="surface">
-          <p className="section-label">Lifecycle snapshot</p>
-          <h2>Core CLI flow</h2>
-          <ol className="steps">
-            {lifecycleSteps.map((step) => (
-              <li key={step.command}>
-                <code>{step.command}</code>
-                <strong>{step.title}</strong>
-                <span>{step.detail}</span>
-              </li>
-            ))}
-          </ol>
-        </article>
-      </section>
+      <ManifestInspector />
     </main>
   );
 }

--- a/webapp/src/components/LifecycleStepper.tsx
+++ b/webapp/src/components/LifecycleStepper.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { LIFECYCLE_STEPS } from "../data/lifecycle";
+import type { LifecycleStep } from "../data/lifecycle";
+
+type StepStatus = "done" | "active" | "pending";
+
+function statusIcon(s: StepStatus): string {
+  if (s === "done")   return "✓";
+  if (s === "active") return "→";
+  return "○";
+}
+
+function fileActionClass(action: string): string {
+  if (action === "created")  return "lc-file--created";
+  if (action === "modified") return "lc-file--modified";
+  return "lc-file--deleted";
+}
+
+function fileActionLabel(action: string): string {
+  if (action === "created")  return "+";
+  if (action === "modified") return "~";
+  return "−";
+}
+
+function DetailPanel({ step, status }: { step: LifecycleStep; status: StepStatus }) {
+  const [copied, setCopied] = useState(false);
+
+  function copy() {
+    navigator.clipboard.writeText(step.command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    });
+  }
+
+  return (
+    <div className="lc-detail" role="tabpanel">
+      <div className="lc-detail-header">
+        <span className={`lc-status-badge lc-status--${status}`}>
+          {statusIcon(status)} {status}
+        </span>
+        <h3 className="lc-detail-title">{step.title}</h3>
+        <p className="lc-detail-summary">{step.summary}</p>
+      </div>
+
+      {/* Command */}
+      <div className="lc-command-block">
+        <span className="lc-block-label">Command</span>
+        <div className="lc-command-row">
+          <code className="lc-command">{step.command}</code>
+          <button className="reg-copy-btn" onClick={copy} aria-label="Copy command">
+            {copied ? "copied ✓" : "copy"}
+          </button>
+        </div>
+      </div>
+
+      {/* Internal explanation */}
+      <div className="lc-internal-block">
+        <span className="lc-block-label">What the Librarian does</span>
+        <p className="lc-internal-text">{step.internal}</p>
+      </div>
+
+      {/* Files */}
+      {step.files.length > 0 && (
+        <div className="lc-files-block">
+          <span className="lc-block-label">Files affected</span>
+          <ul className="lc-file-list" aria-label="Files affected">
+            {step.files.map((f) => (
+              <li key={f.path} className={`lc-file-row ${fileActionClass(f.action)}`}>
+                <span className="lc-file-action" aria-label={f.action}>
+                  {fileActionLabel(f.action)}
+                </span>
+                <code className="lc-file-path">{f.path}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {step.files.length === 0 && (
+        <div className="lc-files-block">
+          <span className="lc-block-label">Files affected</span>
+          <p className="lc-no-files">No files written — read-only operation.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function LifecycleStepper() {
+  const [active, setActive] = useState(0);
+
+  return (
+    <section className="lifecycle" id="lifecycle">
+      <div className="lifecycle-intro">
+        <h2 className="lifecycle-title">Agent Lifecycle</h2>
+        <p className="lifecycle-lede">
+          Step-by-step walkthrough of how <code>agentfactory-gen</code> manages an
+          agent from scaffold to distribution. Click any step to explore it.
+        </p>
+      </div>
+
+      <div className="lc-panels surface">
+        {/* Step rail */}
+        <nav className="lc-rail" aria-label="Lifecycle steps">
+          {LIFECYCLE_STEPS.map((step, i) => {
+            const status: StepStatus =
+              i < active ? "done" : i === active ? "active" : "pending";
+            return (
+              <button
+                key={step.id}
+                className={`lc-step${i === active ? " lc-step--active" : ""}`}
+                onClick={() => setActive(i)}
+                aria-selected={i === active}
+                role="tab"
+              >
+                <span className={`lc-step-icon lc-step-icon--${status}`}>
+                  {statusIcon(status)}
+                </span>
+                <span className="lc-step-body">
+                  <span className="lc-step-title">{step.title}</span>
+                  <code className="lc-step-cmd">{step.command.split(" ").slice(0, 2).join(" ")} …</code>
+                </span>
+                {i < LIFECYCLE_STEPS.length - 1 && (
+                  <span className="lc-connector" aria-hidden="true" />
+                )}
+              </button>
+            );
+          })}
+        </nav>
+
+        {/* Detail panel */}
+        <DetailPanel
+          step={LIFECYCLE_STEPS[active]}
+          status="active"
+        />
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/components/ManifestInspector.tsx
+++ b/webapp/src/components/ManifestInspector.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import {
+  MANIFEST_MINIMAL,
+  MANIFEST_FULL,
+  MANIFEST_FIELDS,
+} from "../data/manifest";
+
+type Variant = "minimal" | "full";
+
+function getAnnotation(key: string): string {
+  return MANIFEST_FIELDS.find((f) => f.key === key)?.annotation ?? "";
+}
+
+function JsonLine({
+  depth,
+  keyName,
+  value,
+  comma,
+}: {
+  depth: number;
+  keyName?: string;
+  value: unknown;
+  comma: boolean;
+}) {
+  const indent = "  ".repeat(depth);
+  const annotation = keyName ? getAnnotation(keyName) : "";
+
+  if (value === null || typeof value !== "object") {
+    const rendered =
+      typeof value === "string" ? `"${value}"` : String(value);
+    return (
+      <div className="mj-line" title={annotation || undefined}>
+        <span className="mj-indent">{indent}</span>
+        {keyName && (
+          <>
+            <span className="mj-key" data-annotated={!!annotation}>
+              "{keyName}"
+            </span>
+            <span className="mj-colon">: </span>
+          </>
+        )}
+        <span className="mj-value">{rendered}</span>
+        {comma && <span className="mj-comma">,</span>}
+        {annotation && <span className="mj-annotation"> // {annotation}</span>}
+      </div>
+    );
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return (
+        <div className="mj-line" title={annotation || undefined}>
+          <span className="mj-indent">{indent}</span>
+          {keyName && (
+            <>
+              <span className="mj-key" data-annotated={!!annotation}>"{keyName}"</span>
+              <span className="mj-colon">: </span>
+            </>
+          )}
+          <span className="mj-bracket">[]</span>
+          {comma && <span className="mj-comma">,</span>}
+          {annotation && <span className="mj-annotation"> // {annotation}</span>}
+        </div>
+      );
+    }
+    return (
+      <>
+        <div className="mj-line" title={annotation || undefined}>
+          <span className="mj-indent">{indent}</span>
+          {keyName && (
+            <>
+              <span className="mj-key" data-annotated={!!annotation}>"{keyName}"</span>
+              <span className="mj-colon">: </span>
+            </>
+          )}
+          <span className="mj-bracket">[</span>
+          {annotation && <span className="mj-annotation"> // {annotation}</span>}
+        </div>
+        {value.map((item, i) => (
+          <JsonLine
+            key={i}
+            depth={depth + 1}
+            value={item}
+            comma={i < value.length - 1}
+          />
+        ))}
+        <div className="mj-line">
+          <span className="mj-indent">{indent}</span>
+          <span className="mj-bracket">]</span>
+          {comma && <span className="mj-comma">,</span>}
+        </div>
+      </>
+    );
+  }
+
+  // object
+  const entries = Object.entries(value as Record<string, unknown>);
+  return (
+    <>
+      <div className="mj-line" title={annotation || undefined}>
+        <span className="mj-indent">{indent}</span>
+        {keyName && (
+          <>
+            <span className="mj-key" data-annotated={!!annotation}>"{keyName}"</span>
+            <span className="mj-colon">: </span>
+          </>
+        )}
+        <span className="mj-bracket">{"{"}</span>
+        {annotation && <span className="mj-annotation"> // {annotation}</span>}
+      </div>
+      {entries.map(([k, v], i) => (
+        <JsonLine
+          key={k}
+          depth={depth + 1}
+          keyName={k}
+          value={v}
+          comma={i < entries.length - 1}
+        />
+      ))}
+      <div className="mj-line">
+        <span className="mj-indent">{indent}</span>
+        <span className="mj-bracket">{"}"}</span>
+        {comma && <span className="mj-comma">,</span>}
+      </div>
+    </>
+  );
+}
+
+export function ManifestInspector() {
+  const [variant, setVariant] = useState<Variant>("minimal");
+  const [copied, setCopied] = useState(false);
+
+  const data = variant === "minimal" ? MANIFEST_MINIMAL : MANIFEST_FULL;
+  const json = JSON.stringify(data, null, 2);
+
+  function copy() {
+    navigator.clipboard.writeText(json).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    });
+  }
+
+  const entries = Object.entries(data);
+
+  return (
+    <section className="manifest-inspector" id="manifest">
+      <div className="manifest-intro">
+        <h2 className="manifest-title">Manifest Inspector</h2>
+        <p className="manifest-lede">
+          The <code>agent-manifest.json</code> is the single source of truth for
+          every agent — its resources, dependencies, and metadata. Hover any
+          highlighted key for an explanation.
+        </p>
+      </div>
+
+      <div className="manifest-panel surface">
+        {/* Toolbar */}
+        <div className="manifest-toolbar">
+          <div className="manifest-variants" role="group" aria-label="Manifest variant">
+            <button
+              className={`mf-variant-btn${variant === "minimal" ? " mf-variant-btn--active" : ""}`}
+              onClick={() => setVariant("minimal")}
+            >
+              Minimal
+            </button>
+            <button
+              className={`mf-variant-btn${variant === "full" ? " mf-variant-btn--active" : ""}`}
+              onClick={() => setVariant("full")}
+            >
+              Full — intelligence layer
+            </button>
+          </div>
+          <button className="reg-copy-btn" onClick={copy} aria-label="Copy JSON">
+            {copied ? "copied ✓" : "copy JSON"}
+          </button>
+        </div>
+
+        {/* Annotated JSON */}
+        <div className="mj-viewer" role="region" aria-label="Manifest JSON">
+          <div className="mj-line">
+            <span className="mj-bracket">{"{"}</span>
+          </div>
+          {entries.map(([k, v], i) => (
+            <JsonLine
+              key={k}
+              depth={1}
+              keyName={k}
+              value={v}
+              comma={i < entries.length - 1}
+            />
+          ))}
+          <div className="mj-line">
+            <span className="mj-bracket">{"}"}</span>
+          </div>
+        </div>
+
+        {/* Field legend */}
+        <div className="mj-legend">
+          <span className="mj-legend-item">
+            <span className="mj-key" data-annotated="true">key</span>
+            hover for annotation
+          </span>
+          <span className="mj-legend-item mj-annotation-sample">
+            // inline annotation
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/webapp/src/data/lifecycle.ts
+++ b/webapp/src/data/lifecycle.ts
@@ -1,0 +1,94 @@
+// lifecycle.ts — full step data for LifecycleStepper
+// <!-- version: 1.0.0 -->
+
+export interface LifecycleFile {
+  path: string;
+  action: "created" | "modified" | "deleted";
+}
+
+export interface LifecycleStep {
+  id: string;
+  command: string;
+  title: string;
+  summary: string;
+  internal: string;
+  files: LifecycleFile[];
+}
+
+export const LIFECYCLE_STEPS: LifecycleStep[] = [
+  {
+    id: "deploy",
+    command: "agentfactory-gen deploy my-agent",
+    title: "Deploy",
+    summary: "Scaffold a new agent with the 5-directory standard structure.",
+    internal:
+      "The Librarian creates the agent directory under .ai/agents/, scaffolds five subdirectories each with a .gitkeep, and writes a minimal agent-manifest.json with empty resource lists and no dependencies.",
+    files: [
+      { path: ".ai/agents/my-agent/skills/.gitkeep",        action: "created" },
+      { path: ".ai/agents/my-agent/commands/.gitkeep",      action: "created" },
+      { path: ".ai/agents/my-agent/scripts/.gitkeep",       action: "created" },
+      { path: ".ai/agents/my-agent/orchestration/.gitkeep", action: "created" },
+      { path: ".ai/agents/my-agent/docs/.gitkeep",          action: "created" },
+      { path: ".ai/agents/my-agent/agent-manifest.json",    action: "created" },
+    ],
+  },
+  {
+    id: "describe",
+    command: "agentfactory-gen describe my-agent --plan",
+    title: "Describe",
+    summary: "Generate a structured plan or human-readable description of the agent.",
+    internal:
+      "The Librarian reads agent-manifest.json, resolves all resource paths, and renders either a plain description or a structured --plan block that lists capabilities, dependencies, and orchestration entry points. Useful for onboarding and documentation.",
+    files: [
+      { path: ".ai/agents/my-agent/agent-manifest.json", action: "modified" },
+    ],
+  },
+  {
+    id: "audit",
+    command: "agentfactory-gen audit my-agent",
+    title: "Audit",
+    summary: "Validate all manifest paths, dependencies, and harness health.",
+    internal:
+      "The Librarian walks every path listed in agent-manifest.json and verifies it exists and is readable. It also checks for dependency cycles, validates semver fields, and flags harness drift (symlinks pointing to missing targets). Returns a scored audit report.",
+    files: [],
+  },
+  {
+    id: "wrap",
+    command: "agentfactory-gen wrap my-agent",
+    title: "Wrap",
+    summary: "Bundle the agent into a Portable Unit ZIP for distribution.",
+    internal:
+      "After passing an internal audit, the Librarian calls sync() to refresh resource lists, then packages the agent directory plus its manifest into a timestamped ZIP. The resulting Portable Unit is self-contained and can be imported into any project running AgentFactory.",
+    files: [
+      { path: "my-agent-v1.0.0.zip", action: "created" },
+    ],
+  },
+  {
+    id: "import",
+    command: "agentfactory-gen import my-agent-v1.0.0.zip",
+    title: "Import",
+    summary: "Unpack and register a Portable Unit into the local harness.",
+    internal:
+      "The Librarian peeks the ZIP manifest, unpacks to .ai/agents/<name>/, runs a deep audit, then registers the agent in the global agent-manifest.json. It updates all active adapter briefs (CLAUDE.md, AGENTS.md, GEMINI.md) to include the new agent's capabilities.",
+    files: [
+      { path: ".ai/agents/my-agent/",               action: "created" },
+      { path: ".ai/agent-manifest.json",             action: "modified" },
+      { path: "CLAUDE.md",                           action: "modified" },
+      { path: "AGENTS.md",                           action: "modified" },
+    ],
+  },
+  {
+    id: "uninstall",
+    command: "agentfactory-gen uninstall my-agent",
+    title: "Uninstall",
+    summary: "Deregister and remove an agent from the harness.",
+    internal:
+      "The Librarian removes the agent entry from the global agent-manifest.json, updates all active adapter briefs to strip the agent's capabilities, then deletes the agent directory. Rolls back briefs first so the harness is never left in an inconsistent state.",
+    files: [
+      { path: ".ai/agents/my-agent/",   action: "deleted" },
+      { path: ".ai/agent-manifest.json", action: "modified" },
+      { path: "CLAUDE.md",               action: "modified" },
+      { path: "AGENTS.md",               action: "modified" },
+    ],
+  },
+];

--- a/webapp/src/data/manifest.ts
+++ b/webapp/src/data/manifest.ts
@@ -1,0 +1,65 @@
+// manifest.ts — sample agent-manifest.json variants for ManifestInspector
+// <!-- version: 1.0.0 -->
+
+export interface ManifestField {
+  key: string;
+  annotation: string;
+}
+
+export const MANIFEST_FIELDS: ManifestField[] = [
+  { key: "name",               annotation: "Unique agent identifier. Used as directory name and registry slug." },
+  { key: "version",            annotation: "Semantic version (MAJOR.MINOR.PATCH). Bumped on every wrap." },
+  { key: "description",        annotation: "Human-readable summary. Appears in CLAUDE.md and registry listings." },
+  { key: "orchestration_plan", annotation: "Entry point the LLM executes first. Usually a plan.json or main.py." },
+  { key: "resources",          annotation: "Tracked file lists per category. Paths are relative to the agent root." },
+  { key: "skills",             annotation: "Skill manifests or SKILL.md files this agent declares." },
+  { key: "commands",           annotation: "CLI command documentation files (one per slash-command)." },
+  { key: "scripts",            annotation: "Executable scripts the LLM can invoke." },
+  { key: "orchestration",      annotation: "Workflow definition files (plan.json, etc.)." },
+  { key: "docs",               annotation: "Documentation files included in the bundle." },
+  { key: "dependencies",       annotation: "Cross-resource dependency map. Keyed by resource path." },
+  { key: "imported_at",        annotation: "ISO 8601 timestamp set at import time. Not set on deploy." },
+  { key: "git_ref",            annotation: "Git commit SHA at time of import — provenance tracking." },
+  { key: "skills_metadata",    annotation: "Arbitrary metadata per skill subdirectory (injected by intelligence layer)." },
+];
+
+export const MANIFEST_MINIMAL = {
+  name: "my-agent",
+  version: "1.0.0",
+  description: "A minimal AgentFactory-compatible agent.",
+  resources: {
+    skills:        [],
+    commands:      [],
+    scripts:       [],
+    orchestration: [],
+    docs:          [],
+  },
+};
+
+export const MANIFEST_FULL = {
+  name: "git-workflow-agent",
+  version: "2.3.0",
+  description: "Git workflow automation with semantic versioning and PR management.",
+  orchestration_plan: "orchestration/plan.json",
+  resources: {
+    skills: [
+      "skills/git-versioning/skill-manifest.json",
+      "skills/diff-visualizer/skill-manifest.json",
+    ],
+    commands:      ["commands/git-workflow.md"],
+    scripts:       ["scripts/bump.py", "scripts/changelog.py"],
+    orchestration: ["orchestration/plan.json"],
+    docs:          ["docs/CLAUDE.md"],
+  },
+  dependencies: {
+    "scripts/changelog.py": ["scripts/bump.py"],
+  },
+  skills_metadata: {
+    "skills/git-versioning": {
+      version: "1.3.1",
+      triggers: "bump version, tag release, open PR",
+    },
+  },
+  imported_at: "2026-04-14T17:32:45Z",
+  git_ref:     "3d83de5",
+};

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -976,3 +976,424 @@ code {
 }
 
 /* ── end Registry Browser ─────────────────────────── */
+
+/* ── Lifecycle Stepper ────────────────────────────── */
+
+.lifecycle {
+  margin-top: 1.25rem;
+}
+
+.lifecycle-intro {
+  margin-bottom: 1rem;
+}
+
+.lifecycle-title {
+  font-family: var(--ce-font-display);
+  font-size: 1.5rem;
+  margin: 0 0 0.4rem;
+}
+
+.lifecycle-lede {
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+/* two-panel */
+
+.lc-panels {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+/* step rail */
+
+.lc-rail {
+  border-right: 1px solid var(--ce-border);
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+  overflow-y: auto;
+}
+
+.lc-step {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0.7rem 1rem 0.7rem 0.75rem;
+  cursor: pointer;
+  text-align: left;
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  transition: background 0.1s;
+}
+
+.lc-step:hover {
+  background: var(--ce-surface-strong);
+}
+
+.lc-step--active {
+  background: var(--ce-surface-strong);
+  border-left: 2px solid var(--ce-accent);
+}
+
+.lc-step-icon {
+  font-size: 0.78rem;
+  width: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+.lc-step-icon--done    { color: var(--ce-accent); }
+.lc-step-icon--active  { color: var(--ce-accent-strong); font-weight: 700; }
+.lc-step-icon--pending { color: var(--ce-text-soft); }
+
+.lc-step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.lc-step-title {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ce-text);
+}
+
+.lc-step--active .lc-step-title {
+  color: var(--ce-accent-strong);
+}
+
+.lc-step-cmd {
+  font-size: 0.7rem;
+  color: var(--ce-text-soft);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+/* detail panel */
+
+.lc-detail {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  overflow-y: auto;
+}
+
+.lc-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.lc-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  width: fit-content;
+}
+
+.lc-status--active  { background: rgba(86, 211, 199, 0.15); color: var(--ce-accent-strong); }
+.lc-status--done    { background: rgba(86, 211, 199, 0.1);  color: var(--ce-accent); }
+.lc-status--pending { background: var(--ce-surface-strong); color: var(--ce-text-soft); }
+
+.lc-detail-title {
+  font-family: var(--ce-font-display);
+  font-size: 1.3rem;
+  margin: 0;
+}
+
+.lc-detail-summary {
+  color: var(--ce-text-soft);
+  margin: 0;
+  line-height: 1.55;
+}
+
+.lc-block-label {
+  display: block;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ce-accent-strong);
+  margin-bottom: 0.4rem;
+}
+
+/* command block */
+
+.lc-command-block,
+.lc-internal-block,
+.lc-files-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.lc-command-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 10px;
+  padding: 0.55rem 0.8rem;
+}
+
+.lc-command {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--ce-accent-strong);
+  word-break: break-all;
+}
+
+.lc-internal-text {
+  font-size: 0.88rem;
+  color: var(--ce-text-soft);
+  line-height: 1.65;
+  margin: 0;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+}
+
+/* file list */
+
+.lc-file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.lc-file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.8rem;
+  border-bottom: 1px solid var(--ce-border);
+  font-size: 0.82rem;
+}
+
+.lc-file-row:last-child { border-bottom: none; }
+
+.lc-file-action {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-weight: 700;
+  width: 1rem;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.lc-file--created  .lc-file-action { color: var(--ce-accent); }
+.lc-file--modified .lc-file-action { color: #ce8922; }
+.lc-file--deleted  .lc-file-action { color: #c03030; }
+
+@media (prefers-color-scheme: dark) {
+  .lc-file--modified .lc-file-action { color: #f5c76a; }
+  .lc-file--deleted  .lc-file-action { color: #ff8080; }
+}
+
+.lc-file-path {
+  color: var(--ce-text-soft);
+  font-size: 0.8rem;
+}
+
+.lc-no-files {
+  font-size: 0.82rem;
+  color: var(--ce-text-soft);
+  font-style: italic;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+@media (max-width: 900px) {
+  .lc-panels {
+    grid-template-columns: 1fr;
+  }
+  .lc-rail {
+    border-right: none;
+    border-bottom: 1px solid var(--ce-border);
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 0.5rem;
+    gap: 0.25rem;
+  }
+  .lc-step {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    padding: 0.5rem 0.6rem;
+    min-width: 80px;
+    border-left: none;
+    border-bottom: 2px solid transparent;
+  }
+  .lc-step--active {
+    border-left: none;
+    border-bottom-color: var(--ce-accent);
+  }
+  .lc-step-cmd { display: none; }
+}
+
+/* ── end Lifecycle Stepper ────────────────────────── */
+
+/* ── Manifest Inspector ───────────────────────────── */
+
+.manifest-inspector {
+  margin-top: 1.25rem;
+}
+
+.manifest-intro {
+  margin-bottom: 1rem;
+}
+
+.manifest-title {
+  font-family: var(--ce-font-display);
+  font-size: 1.5rem;
+  margin: 0 0 0.4rem;
+}
+
+.manifest-lede {
+  color: var(--ce-text-soft);
+  margin: 0;
+}
+
+.manifest-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+/* toolbar */
+
+.manifest-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--ce-border);
+}
+
+.manifest-variants {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.mf-variant-btn {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: transparent;
+  color: var(--ce-text-soft);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.mf-variant-btn:hover {
+  background: var(--ce-surface-strong);
+  color: var(--ce-text);
+}
+
+.mf-variant-btn--active {
+  background: var(--ce-accent);
+  color: #fffdf8;
+  border-color: transparent;
+}
+
+/* JSON viewer */
+
+.mj-viewer {
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.82rem;
+  line-height: 1.7;
+}
+
+.mj-line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  min-height: 1.7em;
+}
+
+.mj-indent {
+  white-space: pre;
+  flex-shrink: 0;
+}
+
+.mj-key {
+  color: var(--ce-accent-strong);
+}
+
+.mj-key[data-annotated="true"] {
+  text-decoration: underline dotted;
+  cursor: help;
+}
+
+.mj-colon { color: var(--ce-text-soft); }
+
+.mj-value {
+  color: var(--ce-text);
+}
+
+.mj-bracket { color: var(--ce-text-soft); }
+.mj-comma   { color: var(--ce-text-soft); }
+
+.mj-annotation {
+  font-size: 0.74rem;
+  color: var(--ce-text-soft);
+  opacity: 0.7;
+  margin-left: 0.5rem;
+  font-style: italic;
+  white-space: nowrap;
+}
+
+/* legend */
+
+.mj-legend {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 0.6rem 1.25rem;
+  border-top: 1px solid var(--ce-border);
+  flex-wrap: wrap;
+}
+
+.mj-legend-item {
+  font-size: 0.75rem;
+  color: var(--ce-text-soft);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mj-annotation-sample {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+/* ── end Manifest Inspector ───────────────────────── */


### PR DESCRIPTION
## Summary

- **LifecycleStepper** — interactive 6-step timeline: deploy → describe → audit → wrap → import → uninstall
  - Each step: CLI command with copy button, Librarian internal explanation, file diff list (created/modified/deleted)
  - Click any step to jump; status icons ✓/→/○ derive from active index
  - Responsive: collapses to horizontal scroll rail on mobile
- **ManifestInspector** — annotated `agent-manifest.json` renderer
  - Toggle: Minimal (empty resources) ↔ Full (intelligence layer with skills_metadata, dependencies, git_ref)
  - Underlined keys with hover tooltips for all 14 annotated fields
  - Inline `// annotation` comments on each key
  - Copy full JSON button
- Replaces the static `split` lifecycle list in `App.tsx`
- 43 modules, `npm run build` passes TypeScript strict + Vite

## Acceptance criteria

- [x] LifecycleStepper: all 6 steps with CLI command + internal explanation + file list
- [x] ManifestInspector: all manifest fields annotated, both variants toggle correctly
- [x] Keyboard accessible (button roles, tabpanel, aria-label, aria-selected)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)