### PR TITLE
feat: GitHub OAuth auth UI — AuthContext, AuthBar, plan badges (#83)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -4,10 +4,16 @@ import { CompletenessViewer } from "./components/CompletenessViewer";
 import { RegistryBrowser } from "./components/RegistryBrowser";
 import { LifecycleStepper } from "./components/LifecycleStepper";
 import { ManifestInspector } from "./components/ManifestInspector";
+import { AuthBar } from "./components/AuthBar";
 
 function App() {
   return (
     <main className="shell">
+      <header className="site-header">
+        <span className="site-header-brand">AgentFactory</span>
+        <AuthBar />
+      </header>
+
       <section className="hero">
         <p className="eyebrow">AgentFactory Platform</p>
         <h1>Production-ready scaffold for the AgentFactory web experience.</h1>

--- a/webapp/src/components/AuthBar.tsx
+++ b/webapp/src/components/AuthBar.tsx
@@ -1,0 +1,116 @@
+// AuthBar.tsx — sign-in button + user badge for the site header
+// <!-- version: 1.0.0 -->
+
+import { useState, useRef, useEffect } from "react";
+import { useAuth } from "../context/AuthContext";
+import type { Plan } from "../types/auth";
+
+const PLAN_LABEL: Record<Plan, string> = {
+  free:       "free",
+  pro:        "pro",
+  team:       "team",
+  enterprise: "enterprise",
+};
+
+const PLAN_CLASS: Record<Plan, string> = {
+  free:       "plan--free",
+  pro:        "plan--pro",
+  team:       "plan--team",
+  enterprise: "plan--enterprise",
+};
+
+export function AuthBar() {
+  const { user, loading, login, logout } = useAuth();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  if (loading) {
+    return <span className="auth-loading" aria-label="Loading auth state" />;
+  }
+
+  if (!user) {
+    return (
+      <button className="auth-signin" onClick={login} aria-label="Sign in with GitHub">
+        <GitHubIcon />
+        Sign in with GitHub
+      </button>
+    );
+  }
+
+  return (
+    <div className="auth-user" ref={menuRef}>
+      <button
+        className="auth-avatar-btn"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label={`@${user.github_handle} — open account menu`}
+      >
+        <img
+          className="auth-avatar"
+          src={user.avatar_url}
+          alt={`@${user.github_handle}`}
+          width={28}
+          height={28}
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = "none";
+          }}
+        />
+        <span className="auth-handle">@{user.github_handle}</span>
+        <span className={`auth-plan ${PLAN_CLASS[user.plan]}`}>
+          {PLAN_LABEL[user.plan]}
+        </span>
+      </button>
+
+      {open && (
+        <div className="auth-menu" role="menu" aria-label="Account menu">
+          <div className="auth-menu-header">
+            <strong className="auth-menu-handle">@{user.github_handle}</strong>
+            <span className="auth-menu-email">{user.email}</span>
+          </div>
+          <hr className="auth-menu-divider" />
+          <button
+            className="auth-menu-item"
+            role="menuitem"
+            onClick={() => { setOpen(false); logout(); }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      className="auth-gh-icon"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+               0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13
+               -.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66
+               .07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15
+               -.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09
+               2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82
+               2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01
+               2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}

--- a/webapp/src/context/AuthContext.tsx
+++ b/webapp/src/context/AuthContext.tsx
@@ -1,0 +1,86 @@
+// AuthContext.tsx — auth state provider
+// <!-- version: 1.0.0 -->
+//
+// Production wiring:
+//   Set VITE_AUTH_API_URL to your FastAPI backend root.
+//   The provider will call GET /auth/me on mount to rehydrate session
+//   from the httpOnly cookie set by /auth/github/callback.
+//
+//   login()  → redirects to GET /auth/github
+//   logout() → calls POST /auth/logout, clears local state
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { AuthState, User } from "../types/auth";
+
+const AuthContext = createContext<AuthState>({
+  user: null,
+  loading: false,
+  login: () => {},
+  logout: () => {},
+});
+
+const API = import.meta.env.VITE_AUTH_API_URL as string | undefined;
+
+// ---------------------------------------------------------------------------
+// Mock user — removed once VITE_AUTH_API_URL is set
+// ---------------------------------------------------------------------------
+const MOCK_USER: User = {
+  id:            "mock-001",
+  github_id:     12345678,
+  github_handle: "matheusmlopess",
+  email:         "matheusmlopess@gmail.com",
+  avatar_url:    "https://avatars.githubusercontent.com/u/12345678?v=4",
+  plan:          "free",
+};
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser]       = useState<User | null>(null);
+  const [loading, setLoading] = useState(!!API);
+
+  useEffect(() => {
+    if (!API) {
+      // No backend configured — start logged-out (demo mode)
+      setLoading(false);
+      return;
+    }
+    fetch(`${API}/auth/me`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: User | null) => setUser(data))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function login() {
+    if (API) {
+      window.location.href = `${API}/auth/github`;
+    } else {
+      // Demo mode: simulate login with mock user
+      setUser(MOCK_USER);
+    }
+  }
+
+  function logout() {
+    if (API) {
+      fetch(`${API}/auth/logout`, { method: "POST", credentials: "include" })
+        .finally(() => setUser(null));
+    } else {
+      setUser(null);
+    }
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  return useContext(AuthContext);
+}

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./context/AuthContext";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -1397,3 +1397,180 @@ code {
 }
 
 /* ── end Manifest Inspector ───────────────────────── */
+
+/* ── Site header + Auth ───────────────────────────── */
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.site-header-brand {
+  font-family: var(--ce-font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--ce-accent-strong);
+  letter-spacing: -0.01em;
+}
+
+/* sign-in button */
+
+.auth-signin {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: var(--ce-surface);
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.auth-signin:hover {
+  background: var(--ce-surface-strong);
+  border-color: var(--ce-accent);
+}
+
+.auth-gh-icon {
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+/* loading skeleton */
+
+.auth-loading {
+  display: inline-block;
+  width: 6rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  background: var(--ce-surface-strong);
+  animation: auth-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes auth-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%       { opacity: 1; }
+}
+
+/* logged-in user badge */
+
+.auth-user {
+  position: relative;
+}
+
+.auth-avatar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.75rem 0.3rem 0.35rem;
+  border-radius: 999px;
+  border: 1px solid var(--ce-border);
+  background: var(--ce-surface);
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.auth-avatar-btn:hover {
+  background: var(--ce-surface-strong);
+}
+
+.auth-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--ce-surface-strong);
+}
+
+.auth-handle {
+  font-family: "SFMono-Regular", "Consolas", monospace;
+  font-size: 0.82rem;
+}
+
+/* plan badge */
+
+.auth-plan {
+  font-size: 0.68rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.plan--free       { background: var(--ce-surface-strong);        color: var(--ce-text-soft); }
+.plan--pro        { background: rgba(206, 137, 34, 0.18);        color: #7a4f00; }
+.plan--team       { background: rgba(86, 211, 199, 0.15);        color: var(--ce-accent-strong); }
+.plan--enterprise { background: rgba(120, 80, 200, 0.12);        color: #5b3ea6; }
+
+@media (prefers-color-scheme: dark) {
+  .plan--pro        { color: #f5c76a; }
+  .plan--enterprise { color: #c4aaff; }
+}
+
+/* dropdown menu */
+
+.auth-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 180px;
+  background: var(--ce-surface-strong);
+  border: 1px solid var(--ce-border);
+  border-radius: 14px;
+  box-shadow: var(--ce-shadow);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.auth-menu-header {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.auth-menu-handle {
+  font-size: 0.88rem;
+  font-family: "SFMono-Regular", "Consolas", monospace;
+}
+
+.auth-menu-email {
+  font-size: 0.75rem;
+  color: var(--ce-text-soft);
+}
+
+.auth-menu-divider {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--ce-border);
+}
+
+.auth-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.65rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  color: var(--ce-text);
+  font-family: var(--ce-font-body);
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.auth-menu-item:hover {
+  background: var(--ce-surface);
+}
+
+/* ── end Site header + Auth ───────────────────────── */

--- a/webapp/src/types/auth.ts
+++ b/webapp/src/types/auth.ts
@@ -1,0 +1,20 @@
+// auth.ts — user identity and auth types
+// <!-- version: 1.0.0 -->
+
+export type Plan = "free" | "pro" | "team" | "enterprise";
+
+export interface User {
+  id: string;
+  github_id: number;
+  github_handle: string;
+  email: string;
+  avatar_url: string;
+  plan: Plan;
+}
+
+export interface AuthState {
+  user: User | null;
+  loading: boolean;
+  login: () => void;
+  logout: () => void;
+}


### PR DESCRIPTION
## Summary

- `AuthContext` + `AuthProvider` — React context holding `user | null`, `login()`, `logout()`
- `useAuth()` hook for any component that needs identity or plan gating
- `AuthBar` — renders in the site header: "Sign in with GitHub" button (logged out) or avatar + handle + plan badge + dropdown (logged in)
- Plan badge variants: free (muted) / pro (amber) / team (teal) / enterprise (purple)
- `main.tsx` wraps `<App>` in `<AuthProvider>`

## Backend wiring (not yet deployed)

Set `VITE_AUTH_API_URL=https://api.agentfactory.dev` to connect the real backend:

| Endpoint | Used for |
|----------|----------|
| `GET /auth/me` | Rehydrate session on mount |
| `GET /auth/github` | Redirect to GitHub OAuth |
| `POST /auth/logout` | Invalidate session cookie |

Without the env var the app runs in **demo mode** — sign-in/out toggles a mock user, no network calls.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)