### PR TITLE
feat: universal harness identity block in every adapter brief

### DIFF
--- a/.ai/AgentFactory.md
+++ b/.ai/AgentFactory.md
@@ -64,6 +64,7 @@ Claude, Codex, and Gemini share the same `.ai/` directory for shared context wit
 <!-- @skills-registry:start -->
 - **diff-visualizer**: Generates HTML diff reports visualizing what changed between two versions of the repo. (See: `.ai/skills/diff-visualizer/SKILL.md`)
 - **git-versioning**: Manages project-wide versioning and repo-state.md updates. (See: `.ai/skills/git-versioning/SKILL.md`)
+- **issue-tracker**: Regenerates the issue priority report and dependency matrix from live GitHub data. (See: `.ai/skills/issue-tracker/SKILL.md`)
 <!-- @skills-registry:end -->
 
 ## Registered Agents

--- a/.ai/adapters/claude/brief.md
+++ b/.ai/adapters/claude/brief.md
@@ -4,13 +4,38 @@
 <!-- @adapter: claude -->
 <!-- @recompile: agentfactory-gen brief -->
 
+## Harness
+
+AgentFactory project. All adapters share the same harness context.
+
+```
+  Harness root : .ai/
+  This adapter : claude
+  Recompile    : agentfactory-gen brief
+```
+
+Shared context (read these to understand the project):
+
+  .ai/skills/               ← skill specs (symlinked per adapter)
+  .ai/rules/                ← behavior rules compiled into this brief
+  .ai/agent-manifest.json   ← global agent registry
+  .ai/memory/milestones.md  ← issue and milestone tracking
+
+All adapter briefs (same project, different CLI):
+
+  claude   CLAUDE.md            → .ai/adapters/claude/brief.md ← YOU ARE HERE
+  codex    AGENTS.md / CODEX.md → .ai/adapters/codex/brief.md
+  gemini   GEMINI.md            → .ai/adapters/gemini/brief.md
+
+If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
+
 ## Available Skills
 
 | Skill | When to invoke | Path |
 |-------|----------------|------|
 | diff-visualizer |  | `.claude/skills/diff-visualizer/SKILL.md` |
 | git-versioning |  | `.claude/skills/git-versioning/SKILL.md` |
-| issue-tracker | regenerate priority report, show dependency matrix, what to work on next | `.claude/skills/issue-tracker/SKILL.md` |
+| issue-tracker |  | `.claude/skills/issue-tracker/SKILL.md` |
 
 ## Commands
 - `/git-workflow` — <!-- version: 1.0.0 -->
@@ -28,5 +53,3 @@
 - **Secrets:** Never log, print, or commit API keys or secrets.
 - **Skill Briefing:** Skill metadata used in compiled briefs must stay brief-safe: keep `description` to a short summary line and `triggers` or `when_to_use` to a short invocation hint instead of procedural detail.
 - **Coverage:** Aim for 80%+ test coverage for new logic.
-- **Feature Workflow:** Every feature follows docs/FEATURE-WORKFLOW.md — issue → branch → implement → CI → PR → merge → milestones → regen priority report. Never skip steps ⑦ and ⑧.
-- **Priority Report:** After every merged PR run `python3 .ai/scripts/generate-priority-report.py`. CI does this automatically on push to dev/main via `issue-tracker.yml`.

--- a/.ai/adapters/codex/brief.md
+++ b/.ai/adapters/codex/brief.md
@@ -4,6 +4,31 @@
 <!-- @adapter: codex -->
 <!-- @recompile: agentfactory-gen brief -->
 
+## Harness
+
+AgentFactory project. All adapters share the same harness context.
+
+```
+  Harness root : .ai/
+  This adapter : codex
+  Recompile    : agentfactory-gen brief
+```
+
+Shared context (read these to understand the project):
+
+  .ai/skills/               ← skill specs (symlinked per adapter)
+  .ai/rules/                ← behavior rules compiled into this brief
+  .ai/agent-manifest.json   ← global agent registry
+  .ai/memory/milestones.md  ← issue and milestone tracking
+
+All adapter briefs (same project, different CLI):
+
+  claude   CLAUDE.md            → .ai/adapters/claude/brief.md
+  codex    AGENTS.md / CODEX.md → .ai/adapters/codex/brief.md ← YOU ARE HERE
+  gemini   GEMINI.md            → .ai/adapters/gemini/brief.md
+
+If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
+
 ## Available Skills
 
 ### diff-visualizer
@@ -14,6 +39,11 @@
 ### git-versioning
 - Description: Manages project-wide versioning and repo-state.md updates.
 - See: .codex/skills/git-versioning/SKILL.md
+- Use when: 
+
+### issue-tracker
+- Description: Regenerates the issue priority report and dependency matrix from live GitHub data.
+- See: .codex/skills/issue-tracker/SKILL.md
 - Use when: 
 
 ## Registered Agents

--- a/.ai/adapters/gemini/brief.md
+++ b/.ai/adapters/gemini/brief.md
@@ -4,6 +4,31 @@
 <!-- @adapter: gemini -->
 <!-- @recompile: agentfactory-gen brief -->
 
+## Harness
+
+AgentFactory project. All adapters share the same harness context.
+
+```
+  Harness root : .ai/
+  This adapter : gemini
+  Recompile    : agentfactory-gen brief
+```
+
+Shared context (read these to understand the project):
+
+  .ai/skills/               ← skill specs (symlinked per adapter)
+  .ai/rules/                ← behavior rules compiled into this brief
+  .ai/agent-manifest.json   ← global agent registry
+  .ai/memory/milestones.md  ← issue and milestone tracking
+
+All adapter briefs (same project, different CLI):
+
+  claude   CLAUDE.md            → .ai/adapters/claude/brief.md
+  codex    AGENTS.md / CODEX.md → .ai/adapters/codex/brief.md
+  gemini   GEMINI.md            → .ai/adapters/gemini/brief.md ← YOU ARE HERE
+
+If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
+
 ## Available Tools
 
 ### diff-visualizer
@@ -15,6 +40,11 @@
 - Description: Manages project-wide versioning and repo-state.md updates.
 - Input: see tool documentation
 - See: .gemini/tools/git-versioning/SKILL.md
+
+### issue-tracker
+- Description: Regenerates the issue priority report and dependency matrix from live GitHub data.
+- Input: see tool documentation
+- See: .gemini/tools/issue-tracker/SKILL.md
 
 ## Registered Agents
 - **test-agent**: Manual Description

--- a/src/agent_gen/librarian.py
+++ b/src/agent_gen/librarian.py
@@ -277,6 +277,49 @@ def _fmt_rules_list(rules: list, config: dict) -> str:
     return "\n".join(lines)
 
 
+def _fmt_harness_identity(adapter_name: str) -> str:
+    """Universal harness identity block — injected into every adapter brief.
+
+    Tells any AI agent (regardless of which CLI it is running in) that this
+    is an AgentFactory project, where the canonical context lives, and how to
+    find the briefs for all other adapters. This is the cross-adapter navigation
+    header that survives a CLI swap.
+    """
+    lines = [
+        "## Harness",
+        "",
+        "AgentFactory project. All adapters share the same harness context.",
+        "",
+        "```",
+        f"  Harness root : {HARNESS_ROOT}/",
+        f"  This adapter : {adapter_name}",
+        f"  Recompile    : agentfactory-gen brief",
+        "```",
+        "",
+        "Shared context (read these to understand the project):",
+        "",
+        f"  {HARNESS_ROOT}/skills/               ← skill specs (symlinked per adapter)",
+        f"  {HARNESS_ROOT}/rules/                ← behavior rules compiled into this brief",
+        f"  {HARNESS_ROOT}/agent-manifest.json   ← global agent registry",
+        f"  {HARNESS_ROOT}/memory/milestones.md  ← issue and milestone tracking",
+        "",
+        "All adapter briefs (same project, different CLI):",
+        "",
+    ]
+    for name, cfg in _FORMAT_REGISTRY.items():
+        root_files = cfg.get("root_files", [])
+        root_display = " / ".join(root_files) if root_files else cfg["output"]
+        marker = " ← YOU ARE HERE" if name == adapter_name else ""
+        lines.append(
+            f"  {name:<8} {root_display:<20} → {HARNESS_ROOT}/adapters/{name}/{cfg['output']}{marker}"
+        )
+    lines += [
+        "",
+        "If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.",
+    ]
+    return "\n".join(lines)
+
+
 _FORMATTER_DISPATCH: dict = {
     "_fmt_skills_table":  _fmt_skills_table,
     "_fmt_skills_blocks": _fmt_skills_blocks,
@@ -1220,6 +1263,7 @@ class Librarian:
             f"<!-- @recompile: agentfactory-gen brief -->"
         )
         sections.append(header)
+        sections.append(_fmt_harness_identity(adapter_name))
         for section_key in config["section_order"]:
             formatter_name = config["sections"].get(section_key)
             if formatter_name is None:

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -579,6 +579,34 @@ class TestCliCommands(unittest.TestCase):
             self.assertIn("brief.md", result.output)
             self.assertIn("ok", result.output)
 
+    def test_brief_contains_harness_identity_block(self):
+        """Every compiled brief contains the universal harness identity block."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            brief = Path(f"{HARNESS_ROOT}/adapters/claude/brief.md")
+            content = brief.read_text()
+            # Block header present
+            self.assertIn("## Harness", content)
+            # Self-reference marker
+            self.assertIn("YOU ARE HERE", content)
+            # Cross-adapter references for all registry adapters
+            self.assertIn("codex", content)
+            self.assertIn("gemini", content)
+            # Key harness paths present
+            self.assertIn("agent-manifest.json", content)
+            self.assertIn("milestones.md", content)
+            self.assertIn("agentfactory-gen brief", content)
+
+    def test_harness_identity_you_are_here_per_adapter(self):
+        """The YOU ARE HERE marker points to the correct adapter in each brief."""
+        with self.runner.isolated_filesystem():
+            self.runner.invoke(cli, ["init", "--primary", "claude"])
+            self.runner.invoke(cli, ["adapter", "add", "codex"])
+            claude_brief = Path(f"{HARNESS_ROOT}/adapters/claude/brief.md").read_text()
+            codex_brief  = Path(f"{HARNESS_ROOT}/adapters/codex/brief.md").read_text()
+            self.assertIn("claude", claude_brief.split("YOU ARE HERE")[0].split("\n")[-1])
+            self.assertIn("codex",  codex_brief.split("YOU ARE HERE")[0].split("\n")[-1])
+
     def test_brief_cmd_no_harness_errors(self):
         """brief command exits non-zero when there is no .ai/ harness."""
         with self.runner.isolated_filesystem():


### PR DESCRIPTION
## Summary

- `_fmt_harness_identity(adapter_name)` injected universally in `_render_brief()` — right after the header, before all adapter-specific sections
- Every compiled brief (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) now carries:
  - Harness root path (`.ai/`)
  - This adapter identity + recompile command
  - Shared context paths: skills, rules, agent-manifest.json, milestones.md
  - Cross-adapter table with all brief locations + `← YOU ARE HERE` marker
- 2 new tests: harness block present in every brief, YOU ARE HERE per-adapter accuracy
- 178/178 tests pass
- CLAUDE.md auto-recompiled on commit showing the live block

## What an agent sees on swap

Starting fresh on Codex in an existing AgentFactory project:

```
## Harness

AgentFactory project. All adapters share the same harness context.

  claude   CLAUDE.md            → .ai/adapters/claude/brief.md
  codex    AGENTS.md / CODEX.md → .ai/adapters/codex/brief.md  ← YOU ARE HERE
  gemini   GEMINI.md            → .ai/adapters/gemini/brief.md

If switching CLI: run `agentfactory-gen brief`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)