### PR TITLE
docs: post-webapp-split cleanup — remove all stale webapp references

### DIFF
--- a/.ai/commands/completeness-check.md
+++ b/.ai/commands/completeness-check.md
@@ -1,0 +1,57 @@
+# Completeness Check
+<!-- version: 1.0.0 -->
+
+Run the skill completeness oracle to verify that a SKILL.md preserves all
+functional behaviour after trimming, or to self-audit a new skill or agent
+before committing.
+
+> **Pro plan required** for `--mode new`, `--mode auto` on uncommitted skills,
+> and all `--agent` checks. Diff mode on committed skills is free.
+> Set plan: `echo '{"plan":"pro"}' > .ai/config/user.json`
+
+## Commands
+
+- **Check global skill (free):**
+  `python3 .ai/scripts/skill-completeness-check.py --skill <name> --adapter <adapter>`
+
+- **Check all skills in an agent (pro):**
+  `python3 .ai/scripts/skill-completeness-check.py --agent <name> --adapter <adapter>`
+
+- **New skill self-audit (pro):**
+  `python3 .ai/scripts/skill-completeness-check.py --skill <name> --mode new --adapter <adapter>`
+
+- **Force diff mode (no fallback):**
+  `python3 .ai/scripts/skill-completeness-check.py --skill <name> --mode diff`
+
+- **Higher accuracy:**
+  Add `--oracle-model claude-sonnet-4-6`
+
+## Modes
+
+| Mode   | When to use                                            | Plan |
+|--------|--------------------------------------------------------|------|
+| `auto` | Default. Detects new vs committed automatically.       | free (diff) / pro (new) |
+| `new`  | Force self-check with auto-trim (Phase 0). Any skill. | pro  |
+| `diff` | Force diff against git baseline. Fails if no baseline. | free |
+
+## Oracle Models
+
+| Model                        | Cost  | Use for                                 |
+|------------------------------|-------|-----------------------------------------|
+| `claude-haiku-4-5-20251001`  | ~1×   | Routine CI / pre-commit (default)       |
+| `claude-sonnet-4-6`          | ~6×   | Pre-merge, complex skills               |
+| `claude-opus-4-6`            | ~20×  | Maximum fidelity, final sign-off        |
+
+## Exit Codes
+
+| Code | Meaning                        |
+|------|--------------------------------|
+| `0`  | Passed threshold               |
+| `1`  | Below threshold                |
+| `2`  | Error (no baseline / API error)|
+| `3`  | Pro plan required              |
+
+## Implementation Details
+
+Refer to `.ai/scripts/skill-completeness-check.py` for the full oracle implementation.
+Full how-to with all scenarios: `docs/HOWTO-COMPLETENESS-CHECK.md`

--- a/.ai/memory/milestones.md
+++ b/.ai/memory/milestones.md
@@ -70,14 +70,18 @@ Status values: `done` · `in-progress` · `pending` · `deferred`
 Business model: freemium SaaS + public agent registry + marketplace.
 The CLI stays open-source. The platform is the paid surface.
 
+> **Note (2026-04-21):** The webapp has been extracted to the private
+> [agentfactory-webapp](https://github.com/matheusmlopess/agentfactory-webapp) repo.
+> Webapp issues (#78, #79, #80, #104, #105) are tracked there going forward.
+
 ### Phase 1 — Foundation
 
 | # | Title | Type | Status | Branch | PR | Commit | Tag |
 |---|-------|------|--------|--------|----|--------|-----|
 | #77 | epic: AgentFactory production platform | epic | pending | — | — | — | — |
-| #78 | feat[P1]: webapp scaffold — Vite + React 19 + TS + GitHub Pages | webapp | in-progress | feature/webapp-scaffold-p1-78 | — | — | — |
-| #79 | feat[P1]: harness explorer UI — two-panel file tree + doc pane | webapp | in-progress | feature/harness-explorer-p1-79 | — | — | — |
-| #80 | feat[P1]: lifecycle stepper + manifest inspector UI components | webapp | done | feature/80-lifecycle-stepper-manifest-inspector | #112 | cf35f7a | — |
+| #78 | feat[P1]: webapp scaffold — Vite + React 19 + TS + GitHub Pages | webapp | moved→webapp-repo | — | — | — | — |
+| #79 | feat[P1]: harness explorer UI — two-panel file tree + doc pane | webapp | moved→webapp-repo | — | — | — | — |
+| #80 | feat[P1]: lifecycle stepper + manifest inspector UI components | webapp | moved→webapp-repo | feature/80-lifecycle-stepper-manifest-inspector | #112 | cf35f7a | — |
 | #81 | feat[P1]: public agent registry — browse, search, publish Portable Units | registry | done | feature/81-public-agent-registry | #111 | 17ae0e3 | — |
 | #82 | feat[P1]: CLI extensions — agentfactory-gen publish + import --from-registry | cli | pending | — | — | — | — |
 
@@ -105,6 +109,15 @@ The CLI stays open-source. The platform is the paid surface.
 | #90 | feat[P4]: marketplace — paid agent listings + purchase flow | marketplace | pending | — | — | — | — |
 | #91 | feat[P4]: verified agent badge — automated Librarian security scan | registry | pending | — | — | — | — |
 | #92 | feat[P4]: publisher revenue share — Stripe Connect payouts | billing | pending | — | — | — | — |
+
+### Webapp track (moved to agentfactory-webapp)
+
+Issues below are tracked in the private webapp repo as of 2026-04-21.
+
+| # | Title | Type | Status |
+|---|-------|------|--------|
+| #104 | webapp completeness report viewer (static, no API key) | feature | moved→webapp-repo |
+| #105 | BYOK live completeness checker in webapp [pro] | feature | moved→webapp-repo |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # AgentFactory
 <!-- version: 2.7.0 -->
 
-A Python CLI (`agentfactory-gen`) and growing SaaS platform for building, packaging,
-and deploying AI agents as portable, framework-agnostic units.
+A Python CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents
+as portable, framework-agnostic units. The web platform lives at
+[agentfactory-webapp](https://github.com/matheusmlopess/agentfactory-webapp) (private).
 
 AgentFactory provides a **Unified AI Harness** — a single `.ai/` directory that lets
 Claude, Codex, and Gemini work on the same project simultaneously, each reading a
@@ -130,6 +131,12 @@ agentfactory-gen uninstall <name>            # remove agent cleanly
 agentfactory-gen import-skill <path>                  # import skill into .ai/skills/
 agentfactory-gen import-skill <path> --to <agent>     # import into a specific agent
 agentfactory-gen retrofit <path>                      # convert Claude/Gemini/Codex layout
+
+# Skill completeness oracle
+python3 .ai/scripts/skill-completeness-check.py --skill <name> --adapter <adapter>
+python3 .ai/scripts/skill-completeness-check.py --agent <name> --adapter <adapter>
+python3 .ai/scripts/skill-completeness-check.py --skill <name> --mode new   # new skill self-check [pro]
+python3 .ai/scripts/skill-completeness-check.py --skill <name> --oracle-model claude-sonnet-4-6
 ```
 
 ### Global flag
@@ -161,16 +168,38 @@ Recompile all active briefs: `agentfactory-gen brief`
 ### Skill Completeness Oracle
 
 A two-phase Claude Haiku oracle that verifies a trimmed `SKILL.md` preserves all
-functional capability of the original:
+functional capability of the original. Supports global skills, agents, and new
+uncommitted skills via Phase 0 auto-trim (pro plan).
 
 ```bash
+# Existing committed skill (free)
 python3 .ai/scripts/skill-completeness-check.py \
   --skill git-versioning --adapter claude
+
+# New/uncommitted skill self-check (pro)
+python3 .ai/scripts/skill-completeness-check.py \
+  --skill my-new-skill --mode new --adapter claude
+
+# All skills in an agent (pro)
+python3 .ai/scripts/skill-completeness-check.py \
+  --agent test-agent --adapter claude
+
+# Higher accuracy
+python3 .ai/scripts/skill-completeness-check.py \
+  --skill git-versioning --oracle-model claude-sonnet-4-6
 ```
 
 Phase 1 extracts **functional atoms** (commands, decision paths, error cases,
-constraints) from the original. Phase 2 verifies each atom is present in the
-trimmed version. Score ≥ threshold → pass.
+constraints) from the original using ephemeral prompt cache. Phase 2 verifies each
+atom is present in the trimmed version. Score ≥ threshold → pass.
+
+**Modes:** `--mode auto` (default, detects new vs committed) · `--mode new` (force
+Phase 0 trim, pro) · `--mode diff` (force git baseline, fails if no baseline)
+
+**Models:** Haiku ~1× cost (default) · Sonnet ~6× · Opus ~20×
+
+**Pro plan gate:** `--mode new`, auto-detected new skills, and `--agent` require
+`{"plan":"pro"}` in `.ai/config/user.json`. Exit code `3` = plan gate triggered.
 
 Per-adapter thresholds in `.ai/config/completeness.json`:
 
@@ -179,6 +208,8 @@ Per-adapter thresholds in `.ai/config/completeness.json`:
 ```
 
 Integrated into: pre-commit hook · dedicated CI job · `adapter add --check-completeness`
+
+Full how-to: [`docs/HOWTO-COMPLETENESS-CHECK.md`](docs/HOWTO-COMPLETENESS-CHECK.md)
 
 ### Harness Doctor
 
@@ -204,47 +235,16 @@ result in the harness.
 
 ---
 
-## Platform & Webapp
-
-The AgentFactory platform is being built as a freemium SaaS on top of the open-source
-CLI. Current status:
-
-| Feature | Status |
-|---------|--------|
-| Webapp scaffold (Vite + React 19 + TS) | Live |
-| Harness Explorer (file tree + doc pane) | Live |
-| Skill Completeness Viewer (cached reports) | Live |
-| Agent Registry (browse + search + install command) | Live — static scaffold |
-| Lifecycle Stepper + Manifest Inspector | Live |
-| GitHub + Google OAuth (frontend) | Live — demo mode |
-| Auth backend (FastAPI, GitHub + Google) | Planned — #114 |
-| Private workspaces + RBAC | Planned — #84 |
-| Pro billing (Stripe) | Planned — #85 |
-| BYOK live completeness checker | Planned — #105 |
-
-Run the webapp locally:
-
-```bash
-cd webapp
-npm install
-npm run dev      # http://localhost:5173
-```
-
----
-
 ## CI/CD
 
 | Trigger | Workflow | What runs |
 |---------|----------|-----------|
-| Push / PR (any branch) | `ci.yml` | ruff lint → pytest (3.11 + 3.12) → coverage ≥ 80% → webapp tsc + build → harness-doctor |
+| Push / PR (any branch) | `ci.yml` | ruff lint → pytest (3.11 + 3.12) → coverage ≥ 80% → harness-doctor |
 | Push / PR (SKILL.md changed) | `skill-completeness.yml` | two-phase completeness oracle per skill |
 | Push to `dev` / `main` | `issue-tracker.yml` | regenerate `docs/ISSUE-PRIORITY.md` |
 | `git tag v*` | `release.yml` | build wheel + sdist → GitHub Release → PyPI |
-| `git tag v*` | `deploy-webapp.yml` | `npm run build` → GitHub Pages |
 
 Branch protection on `dev` requires **Tests + Coverage** to pass before merge.
-
-Live demo: `https://matheusmlopess.github.io/AgentFactory/`
 
 ---
 
@@ -254,12 +254,13 @@ Live demo: `https://matheusmlopess.github.io/AgentFactory/`
 |-----|---------------|
 | [`docs/FEATURE-WORKFLOW.md`](docs/FEATURE-WORKFLOW.md) | 8-step feature lifecycle (issue → branch → implement → CI → PR → merge → milestones → report) |
 | [`docs/SKILL-COMPLETENESS-SPEC.md`](docs/SKILL-COMPLETENESS-SPEC.md) | Two-phase oracle, CLI reference, all integration points |
-| [`docs/HOWTO.md`](docs/HOWTO.md) | Workflow diagrams: deploy, retrofit, wrap, import, uninstall, webapp |
+| [`docs/HOWTO.md`](docs/HOWTO.md) | Workflow diagrams: deploy, retrofit, wrap, import, uninstall |
 | [`docs/FEATURE-AUTH.md`](docs/FEATURE-AUTH.md) | GitHub + Google OAuth system: states, API contract, plan gating |
 | [`docs/FEATURE-HARNESS-IDENTITY.md`](docs/FEATURE-HARNESS-IDENTITY.md) | Cross-adapter navigation block: how it works, swap walkthrough |
 | [`docs/FEATURE-DOC-TEMPLATE.md`](docs/FEATURE-DOC-TEMPLATE.md) | Blank template — every new feature ships one of these |
 | [`docs/ISSUE-PRIORITY.md`](docs/ISSUE-PRIORITY.md) | Live issue priority + wave map (auto-regenerated on every merge) |
 | [`docs/SPEC.md`](docs/SPEC.md) | Technical specification: manifest schema, intelligence layer |
+| [`docs/HOWTO-COMPLETENESS-CHECK.md`](docs/HOWTO-COMPLETENESS-CHECK.md) | All completeness check modes: skill, agent, new-skill, model selection |
 
 ---
 

--- a/docs/FEATURE-AUTH.md
+++ b/docs/FEATURE-AUTH.md
@@ -39,10 +39,13 @@ With auth, they gain a persistent identity, billing tier, and write access.
   │  FILE LAYOUT                                                           │
   └──────────────────────────────────────────────────────────────────────┘
 
-  webapp/src/types/auth.ts              ← User, Plan, AuthState types
-  webapp/src/context/AuthContext.tsx    ← AuthProvider, useAuth() hook
-  webapp/src/components/AuthBar.tsx     ← UI: sign-in button / user badge
-  webapp/src/main.tsx                   ← AuthProvider wraps the app root
+  src/types/auth.ts              ← User, Plan, AuthState types        (agentfactory-webapp)
+  src/context/AuthContext.tsx    ← AuthProvider, useAuth() hook       (agentfactory-webapp)
+  src/components/AuthBar.tsx     ← UI: sign-in button / user badge    (agentfactory-webapp)
+  src/main.tsx                   ← AuthProvider wraps the app root    (agentfactory-webapp)
+
+  All auth UI files are in the private agentfactory-webapp repo:
+  https://github.com/matheusmlopess/agentfactory-webapp
 ```
 
 ### 2.2 React tree

--- a/docs/FEATURE-WORKFLOW.md
+++ b/docs/FEATURE-WORKFLOW.md
@@ -62,7 +62,6 @@ Every unit of work starts as an issue. No branch without an issue.
   │  Label          │  Use for                                          │
   ├─────────────────┼──────────────────────────────────────────────────┤
   │  enhancement    │  Harness / CLI features (no platform label)       │
-  │  webapp         │  React webapp / UI work                           │
   │  cli            │  CLI command changes (with platform for SaaS)     │
   │  platform       │  SaaS platform work — add [P1]–[P4] in title     │
   │  billing        │  Stripe / monetisation (add with platform)        │
@@ -159,13 +158,13 @@ Every push to a PR branch runs these jobs. All must pass before merge is allowed
   ┌─────────────────────────────────────────────────────────────────────┐
   │  CI PIPELINE (.github/workflows/ci.yml)                              │
   │                                                                       │
-  │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
-  │  │  tests           │  │  webapp-build     │  │  harness-doctor  │  │
-  │  │                  │  │                  │  │                  │  │
-  │  │  pytest          │  │  tsc --noEmit    │  │  exit 0  → pass  │  │
-  │  │  80% coverage    │  │  vite build      │  │  exit 1  → warn  │  │
-  │  │                  │  │                  │  │  exit 2  → BLOCK │  │
-  │  └──────────────────┘  └──────────────────┘  └──────────────────┘  │
+  │  ┌──────────────────┐  ┌──────────────────┐                        │
+  │  │  tests           │  │  harness-doctor  │                        │
+  │  │                  │  │                  │                        │
+  │  │  pytest          │  │  exit 0  → pass  │                        │
+  │  │  80% coverage    │  │  exit 1  → warn  │                        │
+  │  │                  │  │  exit 2  → BLOCK │                        │
+  │  └──────────────────┘  └──────────────────┘                        │
   │                                                                       │
   │  ┌──────────────────────────────────────────────────────────────┐   │
   │  │  skill-completeness  (only fires when SKILL.md changes)       │   │

--- a/docs/HOWTO-COMPLETENESS-CHECK.md
+++ b/docs/HOWTO-COMPLETENESS-CHECK.md
@@ -1,0 +1,348 @@
+# HOWTO: Skill Completeness Check
+<!-- version: 1.0.0 -->
+
+The skill completeness oracle verifies that a trimmed `SKILL.md` preserves all
+functional behaviour of the original. It uses a two-phase Claude Haiku pipeline to
+extract **functional atoms** (commands, decision paths, error cases, constraints, etc.)
+from the original, then verifies each atom is present in the trimmed version.
+
+The oracle now supports three modes, agent-level checking, model selection, and a
+pro-plan gate for token-consuming operations.
+
+---
+
+## Quick Reference
+
+```
+python3 .ai/scripts/skill-completeness-check.py [options]
+
+Target (one required):
+  --skill <name>         Global skill: .ai/skills/<name>/SKILL.md
+  --agent <name>         Agent: all SKILL.md under .ai/agents/<name>/skills/  [pro]
+
+Mode:
+  --mode auto            (default) auto-detect: diff if committed, new-skill if not
+  --mode new             Force new-skill self-check (Phase 0 trim)            [pro]
+  --mode diff            Force diff against git baseline. Fails if no baseline.
+
+Model:
+  --oracle-model <id>    (default: claude-haiku-4-5-20251001)
+
+Other:
+  --old <git-ref>        Git ref for baseline (default: HEAD)
+  --adapter <name>       Selects threshold + char limit from config
+  --threshold <int>      Explicit threshold override
+  --out <path>           Report output path
+  --quiet                Suppress terminal output
+```
+
+### Plan gating
+
+| Operation                            | Plan  |
+|--------------------------------------|-------|
+| `--mode diff` on committed skill     | free  |
+| `--mode auto` on committed skill     | free  |
+| `--mode auto` on uncommitted skill   | pro   |
+| `--mode new` (always)                | pro   |
+| `--agent`                            | pro   |
+
+Set your plan: `echo '{"plan":"pro"}' > .ai/config/user.json`
+
+### Oracle models
+
+| Model                        | Cost  | Use for                                  |
+|------------------------------|-------|------------------------------------------|
+| `claude-haiku-4-5-20251001`  | ~1×   | Routine CI / pre-commit (default)        |
+| `claude-sonnet-4-6`          | ~6×   | Pre-merge, higher-accuracy atom extract  |
+| `claude-opus-4-6`            | ~20×  | Maximum fidelity, complex skills         |
+
+### Exit codes
+
+| Code | Meaning                        |
+|------|--------------------------------|
+| `0`  | Passed threshold               |
+| `1`  | Below threshold                |
+| `2`  | Error (no baseline / API)      |
+| `3`  | Pro plan required              |
+
+---
+
+## All Scenarios
+
+### Scenario A — Existing global skill, diff mode (baseline behaviour, free)
+
+```
+  python3 skill-completeness-check.py --skill git-versioning --adapter claude
+
+  is_new_skill("HEAD", ".ai/skills/git-versioning/SKILL.md")
+          │
+          └─ False (committed)
+          │
+          ▼
+  git show HEAD:.ai/skills/git-versioning/SKILL.md  → original
+  read .ai/skills/git-versioning/SKILL.md           → trimmed
+          │
+  Phase 1 — Extract atoms from original (ephemeral cache)
+  Phase 2 — Verify atoms in trimmed
+          │
+          ▼
+  report["mode"] = "diff"  |  report["old_ref"] = "HEAD"
+
+  ════════════════════════════════════════════════════════════
+    skill-completeness-check
+    Skill  : git-versioning
+    Old    : HEAD (v1.3.0)
+    New    : .ai/skills/git-versioning/SKILL.md (v1.3.0)
+    Adapter: claude   Model: claude-haiku-4-5-20251001
+  ════════════════════════════════════════════════════════════
+
+  PASSED: score 98% meets threshold 90%
+```
+
+---
+
+### Scenario B — New global skill, auto-detected (pro gate)
+
+```
+  python3 skill-completeness-check.py --skill my-new-skill --adapter claude
+
+  is_new_skill("HEAD", ".ai/skills/my-new-skill/SKILL.md") → True
+          │
+          ▼
+  require_plan("pro")   ← exits 3 if user.json plan = "free"
+          │
+          ▼
+  read .ai/skills/my-new-skill/SKILL.md  → original content
+          │
+  ╔═══════════════════════════════════════════════════════════╗
+  ║  Phase 0 — Auto-trim              [NEW SKILL MODE]        ║
+  ║  Model: claude-haiku-4-5-20251001 (default)               ║
+  ║  Limit: 18,000 chars (claude adapter)                     ║
+  ║  Output: trimmed_content (in-memory, never on disk)       ║
+  ╚═══════════════════════════════════════════════════════════╝
+          │
+  Phase 1 — Extract atoms from original (ephemeral cache)
+  Phase 2 — Verify atoms in trimmed_content
+          │
+          ▼
+  report["mode"] = "new_skill"  |  report["old_ref"] = "working_tree"
+
+  ════════════════════════════════════════════════════════════
+    skill-completeness-check  [NEW SKILL SELF-CHECK]
+    Skill  : my-new-skill
+    Mode   : new skill — auto-trimmed to 18,000 chars
+    Adapter: claude   Model: claude-haiku-4-5-20251001
+  ════════════════════════════════════════════════════════════
+
+  ● New-skill self-check complete (Phase 0 trim used tokens).
+    Commit first, then re-run to compare against the baseline.
+```
+
+---
+
+### Scenario C — Force new mode on committed skill (cross-adapter preview)
+
+```
+  python3 skill-completeness-check.py --skill git-versioning --mode new --adapter codex
+
+  require_plan("pro")   ← --mode new always requires pro
+          │
+  --mode new → skip is_new_skill(), always run new-skill branch
+  read working tree as "original"
+  Phase 0 — Auto-trim to codex limit: 10,000 chars
+  Phase 1+2 — atoms + verify against trimmed
+          │
+          ▼
+  "If you trim this skill for Codex, you retain X%"
+  report["mode"] = "new_skill"  |  report["adapter"] = "codex"
+
+  Use case: preview what trimming would cost before switching adapters.
+```
+
+---
+
+### Scenario D — Existing agent, all skills checked (pro)
+
+```
+  python3 skill-completeness-check.py --agent test-agent --adapter claude
+
+  require_plan("pro")   ← --agent always requires pro
+          │
+  find_agent_skills("test-agent")
+  → [("git-versioning", ".ai/agents/test-agent/skills/git-versioning/SKILL.md")]
+
+  For each skill:
+  ┌──────────────────────────────────────────────────────────┐
+  │ is_new_skill("HEAD", skill_path)?                        │
+  │   False → diff mode (git show baseline)                  │
+  │   True  → new-skill mode (Phase 0 trim)                  │
+  └──────────────────────────────────────────────────────────┘
+  Phase 1 + Phase 2 per skill
+  report → .ai/reports/agent-test-agent-git-versioning-completeness.json
+
+  ╔══════════════════════════════════════════════════════════════╗
+  ║  Agent Completeness: test-agent                              ║
+  ╠══════════════════════════════════════════════════════════════╣
+  ║  git-versioning        98%  ✓  diff                         ║
+  ╚══════════════════════════════════════════════════════════════╝
+
+  PASSED: 1/1 skills meet threshold (90%)
+```
+
+---
+
+### Scenario E — New agent, all skills new (Phase 0 per skill)
+
+```
+  python3 skill-completeness-check.py --agent my-new-agent --adapter claude
+
+  find_agent_skills("my-new-agent")
+  → [("search", "..."), ("auth", "...")]
+
+  Both → is_new_skill = True → Phase 0 auto-trim per skill
+
+  ╔══════════════════════════════════════════════════════════════╗
+  ║  Agent Completeness: my-new-agent  [NEW SKILL SELF-CHECK]   ║
+  ╠══════════════════════════════════════════════════════════════╣
+  ║  search                 95%  ✓  [NEW]                       ║
+  ║  auth                   87%  ✗  [NEW]                       ║
+  ╚══════════════════════════════════════════════════════════════╝
+
+  FAILED: 1/2 skills below threshold (90%)
+  exit 1
+```
+
+---
+
+### Scenario F — --mode diff, no baseline → hard fail with hint
+
+```
+  python3 skill-completeness-check.py --skill my-new-skill --mode diff
+
+  --mode diff → new_skill = False → tries git show
+  → git show fails → RuntimeError
+          │
+          ▼
+  Error: git show HEAD:.ai/skills/my-new-skill/SKILL.md failed: ...
+  Hint:  Skill has no committed baseline. Use --mode new for a self-check.
+  exit 2
+```
+
+---
+
+### Scenario G — Agent with mixed skills (some committed, some new)
+
+```
+  python3 skill-completeness-check.py --agent my-agent --adapter claude
+
+  find_agent_skills → git-versioning (committed) + new-search (not committed)
+
+  git-versioning: is_new_skill = False → diff mode
+  new-search:     is_new_skill = True  → new-skill mode (Phase 0)
+
+  ╔══════════════════════════════════════════════════════════════╗
+  ║  Agent Completeness: my-agent  [NEW SKILL SELF-CHECK]       ║
+  ╠══════════════════════════════════════════════════════════════╣
+  ║  git-versioning        98%  ✓  diff                         ║
+  ║  new-search            92%  ✓  [NEW]                        ║
+  ╚══════════════════════════════════════════════════════════════╝
+
+  PASSED: 2/2 skills meet threshold (90%)
+```
+
+---
+
+## Report Format
+
+```
+  --skill <name>  → .ai/reports/skill-<name>-completeness.json
+  --agent <name>  → .ai/reports/agent-<agent>-<skill>-completeness.json
+
+  New fields in v2.0.0:
+    "mode":         "diff" | "new_skill"
+    "oracle_model": "claude-haiku-4-5-20251001"
+    "old_ref":      "HEAD" | "working_tree"
+```
+
+Example v2.0.0 report:
+
+```json
+{
+  "skill":        "git-versioning",
+  "mode":         "diff",
+  "oracle_model": "claude-haiku-4-5-20251001",
+  "old_ref":      "HEAD",
+  "old_version":  "1.3.0",
+  "new_version":  "1.3.0",
+  "generated_at": "2026-04-20T12:00:00+00:00",
+  "score":        98,
+  "threshold":    90,
+  "passed":       true,
+  "summary":      { "preserved": 44, "degraded": 1, "missing": 0 },
+  "atoms": [ ... ]
+}
+```
+
+---
+
+## Integration Points
+
+### Pre-commit hook
+
+```bash
+# .git/hooks/pre-commit (or .ai/scripts/pre-commit-completeness.sh)
+if git diff --cached --name-only | grep -q "SKILL.md"; then
+  python3 .ai/scripts/skill-completeness-check.py --skill git-versioning --adapter claude
+  [ $? -ne 0 ] && exit 1
+fi
+```
+
+Exit code 3 (pro gate) should be treated as a warning, not a blocking failure, in free-tier environments.
+
+### CI (GitHub Actions)
+
+```yaml
+- name: Skill completeness check
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    python3 .ai/scripts/skill-completeness-check.py \
+      --skill git-versioning --adapter claude --quiet
+```
+
+For agent-level CI with a pro token:
+
+```yaml
+- name: Agent completeness check
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    AGENTFACTORY_LICENSE_KEY: ${{ secrets.AGENTFACTORY_LICENSE_KEY }}
+  run: |
+    python3 .ai/scripts/skill-completeness-check.py \
+      --agent test-agent --adapter claude --quiet
+```
+
+### Adapter swap preview (Scenario C)
+
+Before switching an agent from Claude → Codex:
+
+```bash
+python3 .ai/scripts/skill-completeness-check.py \
+  --skill git-versioning --mode new --adapter codex \
+  --oracle-model claude-sonnet-4-6
+```
+
+Shows what percentage of atoms survive the 10,000-char Codex limit.
+
+---
+
+## How to add a new skill report
+
+1. Write `.ai/skills/<name>/SKILL.md` following the YAML frontmatter convention.
+2. Run the self-check (pro plan required):
+   ```bash
+   python3 .ai/scripts/skill-completeness-check.py \
+     --skill <name> --mode new --adapter claude
+   ```
+3. Review the report at `.ai/reports/skill-<name>-completeness.json`.
+4. Commit the skill. On the next diff run the oracle will compare against HEAD.

--- a/docs/ISSUE-PRIORITY.md
+++ b/docs/ISSUE-PRIORITY.md
@@ -13,7 +13,6 @@ Source: `.ai/scripts/generate-priority-report.py`  |  Spec: `docs/ISSUE-PRIORITY
   │  Track           │  Issues                                    │
   ├──────────────────┼───────────────────────────────────────────┤
   │  Harness / CLI   │                                             │
-  │  Webapp / UI     │  #88  #105                                  │
   │  Platform Core   │  #77  #82  #84  #85  #86  #114              │
   │  Platform Upper  │  #87  #89  #90  #91  #92                    │
   └──────────────────┴───────────────────────────────────────────┘
@@ -35,7 +34,6 @@ Source: `.ai/scripts/generate-priority-report.py`  |  Spec: `docs/ISSUE-PRIORITY
   #90     #77 #85                   #92                       feat[P4]: marketplace — paid agent listings +
   #91     #77                       —                         feat[P4]: verified agent badge — automated Li
   #92     #77 #89 #90               —                         feat[P4]: publisher revenue share — Stripe Co
-  #105    #85                       —                         feat[pro]: BYOK live completeness checker in 
   #114    —                         —                         feat[P2]: auth backend — FastAPI OAuth server
 ```
 
@@ -75,10 +73,9 @@ Source: `.ai/scripts/generate-priority-report.py`  |  Spec: `docs/ISSUE-PRIORITY
 ```
   #       Effort    Track             Unblocks              Title
   ──────  ────────  ────────────────  ────────────────────  ────────────────────────────────────────
-  #88     medium    Webapp / UI       —                     feat[P3]: agent dependency graph visualizatio
+  #88     medium    Platform Upper    —                     feat[P3]: agent dependency graph visualizatio
   #89     medium    Platform Upper    #92                   feat[P3]: Enterprise compliance export — audi
   #90     large     Platform Upper    #92                   feat[P4]: marketplace — paid agent listings +
-  #105    medium    Webapp / UI       —                     feat[pro]: BYOK live completeness checker in 
 ```
 
 ### Wave 5 — Wave 5
@@ -101,11 +98,8 @@ Key dependencies that span tracks — these are the critical path risks:
   (platform-core)     ├────────────────────►  #85  Pro billing
                       └────────────────────►  #86  login/logout CLI
 
-  #85  Pro billing   ─┬────────────────────►  #105 BYOK live checker
-  (platform-core)     └────────────────────►  #90  marketplace
-
-  #101 CI job        ──────────────────────►  #104 webapp report viewer
-  (harness/CLI)                               (webapp/UI)
+  #85  Pro billing   ──────────────────────►  #90  marketplace
+  (platform-core)
 ```
 
 ---

--- a/docs/SKILL-COMPLETENESS-SPEC.md
+++ b/docs/SKILL-COMPLETENESS-SPEC.md
@@ -346,14 +346,10 @@ deeper trims — less room for behavioral loss is tolerated.
           upload .ai/reports/*.json as artifacts
           exit 1 → blocks PR merge
 
-  Webapp (read-only, no API key)
-  ──────────────────────────────
-  npm run dev / npm run build
-    │
-    └─► node scripts/copy-reports.mjs
-          copies .ai/reports/skill-*.json
-                 → webapp/src/data/reports/
-          CompletenessViewer.tsx renders cached results
+  Webapp viewer (agentfactory-webapp, private repo)
+  ─────────────────────────────────────────────────
+  Reports in .ai/reports/*.json are consumed by the
+  webapp repo. See github.com/matheusmlopess/agentfactory-webapp.
 ```
 
 ### 6.2 Adapter-swap gate in detail
@@ -528,16 +524,11 @@ deeper trims — less room for behavioral loss is tolerated.
   └──────────────────────────────────────────────────────────────────────┘
 
   ┌──────────────────────────────────────────────────────────────────────┐
-  │  TIER 2 — Static Webapp Viewer                          LIVE (#104)   │
+  │  TIER 2 — Webapp Viewer                        moved → webapp-repo   │
   │                                                                        │
-  │  webapp/src/components/CompletenessViewer.tsx                         │
-  │                                                                        │
-  │  • Renders pre-generated JSON reports from .ai/reports/               │
-  │  • Reports embedded at build time via copy-reports.mjs               │
-  │  • No API key needed to view                                          │
-  │  • Skill tabs + score badge + filterable atom list                    │
-  │  • "Re-run" shows CLI command to copy-paste                           │
-  │  • badge: "pro" (free read-only tier of the Pro feature)             │
+  │  Implemented in agentfactory-webapp (private repo).                  │
+  │  Reads .ai/reports/*.json; gated behind FeatureGate plan="pro".      │
+  │  See github.com/matheusmlopess/agentfactory-webapp                   │
   └──────────────────────────────────────────────────────────────────────┘
 
   ┌──────────────────────────────────────────────────────────────────────┐
@@ -590,16 +581,7 @@ deeper trims — less room for behavioral loss is tolerated.
          │
          ▼
   ┌──────────────────────────────────────────────────────────────────────┐
-  │  STEP 3 — Refresh webapp (optional, if running locally)               │
-  │                                                                        │
-  │  cd webapp                                                            │
-  │  node scripts/copy-reports.mjs                                       │
-  │  # (or just restart: npm run dev — copy runs automatically)           │
-  └──────────────────────────────────────────────────────────────────────┘
-         │
-         ▼
-  ┌──────────────────────────────────────────────────────────────────────┐
-  │  STEP 4 — CI validates on push / PR                                   │
+  │  STEP 3 — CI validates on push / PR                                   │
   │                                                                        │
   │  .github/workflows/skill-completeness.yml fires (path filter)        │
   │  Re-runs oracle in CI → blocks merge if score < threshold            │
@@ -621,24 +603,6 @@ deeper trims — less room for behavioral loss is tolerated.
   │                                                                        │
   │  python3 .ai/scripts/skill-completeness-check.py \                   │
   │    --skill <name> --adapter claude                                    │
-  └──────────────────────────────────────────────────────────────────────┘
-         │
-         ▼
-  ┌──────────────────────────────────────────────────────────────────────┐
-  │  Register in webapp CompletenessViewer.tsx                           │
-  │                                                                        │
-  │  // 1. Add import                                                     │
-  │  import newReport from                                                │
-  │    "../data/reports/skill-<name>-completeness.json";                 │
-  │                                                                        │
-  │  // 2. Add to REPORTS map                                             │
-  │  const REPORTS = {                                                    │
-  │    "diff-visualizer": diffReport as CompletenessReport,              │
-  │    "git-versioning":  gitReport  as CompletenessReport,              │
-  │    "<name>":          newReport  as CompletenessReport,   // ← add   │
-  │  };                                                                   │
-  │                                                                        │
-  │  Note: auto-discovery of reports is a planned future improvement.    │
   └──────────────────────────────────────────────────────────────────────┘
          │
          ▼
@@ -679,12 +643,12 @@ Completeness check run on 2026-04-16 after the token-budget trim:
   │  #101   │  Dedicated CI job (skill-completeness.yml)    │  ✓ LIVE     │
   │  #102   │  Adapter-add completeness gate                │  ✓ LIVE     │
   │  #103   │  Per-adapter thresholds in config             │  ✓ LIVE     │
-  │  #104   │  Webapp static report viewer                  │  ✓ LIVE     │
-  │  #105   │  BYOK live checker in webapp [pro]            │  ⏳ Wave 5  │
+  │  #104   │  Webapp static report viewer                  │  → webapp-repo │
+  │  #105   │  BYOK live checker in webapp [pro]            │  → webapp-repo │
   └──────────────────────────────────────────────────────────────────────┘
 
-  #105 is gated behind Pro billing (#85) — Wave 4 → unlocks #105 Wave 5.
-  All other completeness track issues are fully shipped as of v1.7.0.
+  #104 and #105 have moved to the private agentfactory-webapp repo (2026-04-21).
+  All CLI-side completeness track issues (#100–#103) are fully shipped as of v1.7.0.
 ```
 
 ---
@@ -704,16 +668,11 @@ Completeness check run on 2026-04-16 after the token-budget trim:
   │  git show HEAD:... failed         │  Ensure fetch-depth: 2 in CI, or  │
   │                                   │  run from inside the git repo      │
   ├───────────────────────────────────┼───────────────────────────────────┤
-  │  Webapp shows stale score         │  Re-run oracle → node             │
-  │                                   │  scripts/copy-reports.mjs          │
-  ├───────────────────────────────────┼───────────────────────────────────┤
   │  harness-doctor skips completeness│  Pass --completeness flag and set │
   │                                   │  ANTHROPIC_API_KEY                 │
   ├───────────────────────────────────┼───────────────────────────────────┤
   │  adapter-add not showing threshold│  Check .ai/config/completeness.json│
   │  from config                      │  — adapter key must match exactly  │
   ├───────────────────────────────────┼───────────────────────────────────┤
-  │  New skill not in webapp tabs     │  Add import + REPORTS entry in    │
-  │                                   │  CompletenessViewer.tsx            │
   └──────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary
- **README**: removed Platform & Webapp section, stale CI/CD rows (`deploy-webapp.yml`, webapp tsc+build), live demo link; updated tagline to reflect CLI-only repo
- **milestones.md**: marked #78/#79/#80 as `moved→webapp-repo`; added archive section for #104/#105
- **ISSUE-PRIORITY.md**: removed `Webapp / UI` track, `#105` row, `#104` cross-track dependency edge
- **FEATURE-WORKFLOW.md**: removed `webapp` track label, `webapp-build` box from CI pipeline diagram
- **SKILL-COMPLETENESS-SPEC.md**: replaced Tier 2 webapp block with cross-repo pointer; removed webapp refresh step, webapp `CompletenessViewer` registration steps; updated status table and troubleshooting table
- **FEATURE-AUTH.md**: updated file layout to reflect `agentfactory-webapp` paths
- **HOWTO-COMPLETENESS-CHECK.md**: replaced `{"plan":"pro"} > user.json` CI snippet with `AGENTFACTORY_LICENSE_KEY` env var (matches new server-side license gate)
- Added previously-untracked `.ai/commands/completeness-check.md` and `docs/HOWTO-COMPLETENESS-CHECK.md`

## Test plan
- [ ] No remaining `webapp/` path references in any `.md` file in this repo
- [ ] No mention of `npm`, `vite`, `copy-reports.mjs`, or `localhost:5173` outside of cross-repo notes
- [ ] CI YAML snippets in docs use `AGENTFACTORY_LICENSE_KEY`, not `user.json` plan write

🤖 Generated with [Claude Code](https://claude.com/claude-code)