### PR TITLE
fix: create all adapter root symlinks on init + inject skills-registry (#120 #121)

### DIFF
--- a/src/agent_gen/cli.py
+++ b/src/agent_gen/cli.py
@@ -249,22 +249,18 @@ def init_project(project_root: str, primary: str):
     Librarian._compile_adapter_briefs(str(project_path))
     _echo("  [wired] adapter capability symlinks + compiled briefs")
 
-    # 5. Root symlinks — primary adapter's root files → its compiled brief
-    #    Folder symlinks for all adapters
-    primary_config = _FORMAT_REGISTRY[primary]
-    brief_target = f"{HARNESS_ROOT}/adapters/{primary}/{primary_config['output']}"
-    brief_exists = (project_path / brief_target).exists()
+    # 5. Root symlinks — all adapters whose brief has been compiled
     fallback_target = f"{HARNESS_ROOT}/{CONTEXT_FILE}"
-
-    # MD root files for the primary adapter only
-    for root_file in primary_config["root_files"]:
-        link_path = project_path / root_file
-        if link_path.exists() or link_path.is_symlink():
-            _echo(f"  [skip] {root_file} (already exists)")
-            continue
-        target = brief_target if brief_exists else fallback_target
-        link_path.symlink_to(target)
-        _echo(f"  [linked] {root_file} -> {target}")
+    for _name, _cfg in _FORMAT_REGISTRY.items():
+        _brief_target = f"{HARNESS_ROOT}/adapters/{_name}/{_cfg['output']}"
+        _target = _brief_target if (project_path / _brief_target).exists() else fallback_target
+        for root_file in _cfg["root_files"]:
+            link_path = project_path / root_file
+            if link_path.exists() or link_path.is_symlink():
+                _echo(f"  [skip] {root_file} (already exists)")
+                continue
+            link_path.symlink_to(_target)
+            _echo(f"  [linked] {root_file} -> {_target}")
 
     # Folder symlinks for all adapters (not adapter-specific)
     for adapter_name in _FORMAT_REGISTRY:

--- a/src/agent_gen/librarian.py
+++ b/src/agent_gen/librarian.py
@@ -1050,6 +1050,8 @@ class Librarian:
                 # Update Skills
                 if "<!-- @skills-registry:start -->" in content:
                     content = skill_pattern.sub(skill_registry_text, content)
+                else:
+                    content = content.strip() + f"\n\n## Available Skills\n{skill_registry_text}\n"
 
                 target_path.write_text(content, encoding="utf-8")
                 updated_paths.add(resolved_path)

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -212,7 +212,7 @@ class TestCliCommands(unittest.TestCase):
             self.runner.invoke(cli, ["deploy", "plan-agent"])
             result = self.runner.invoke(cli, ["describe", "plan-agent", "--plan", "orchestration/missing.json"])
             self.assertEqual(result.exit_code, 0)
-            self.assertIn("Warning", result.output + (result.stderr if hasattr(result, "stderr") else ""))
+            self.assertIn("Warning", result.output)
 
     # --- #48: wrap --out ---
 
@@ -422,7 +422,7 @@ class TestCliCommands(unittest.TestCase):
             self.assertIn("claude", target)
 
     def test_init_primary_flag_codex(self):
-        """--primary codex links AGENTS.md and CODEX.md to codex brief."""
+        """--primary codex links all adapter root files; codex files point to codex brief."""
         with self.runner.isolated_filesystem():
             result = self.runner.invoke(cli, ["init", "--primary", "codex"])
             self.assertEqual(result.exit_code, 0)
@@ -433,8 +433,11 @@ class TestCliCommands(unittest.TestCase):
             self.assertTrue(os.path.islink("CODEX.md"))
             codex_target = os.readlink("CODEX.md")
             self.assertIn("codex", codex_target)
-            # CLAUDE.md should NOT be created (not primary)
-            self.assertFalse(os.path.exists("CLAUDE.md"))
+            # All adapter root files are created (all briefs compile on init)
+            self.assertTrue(os.path.islink("CLAUDE.md"))
+            self.assertIn("claude", os.readlink("CLAUDE.md"))
+            self.assertTrue(os.path.islink("GEMINI.md"))
+            self.assertIn("gemini", os.readlink("GEMINI.md"))
 
     def test_adapter_add_creates_dir_and_brief(self):
         """adapter add creates the adapter dir, config, wiring, brief, and root symlinks."""
@@ -479,11 +482,27 @@ class TestCliCommands(unittest.TestCase):
             self.assertTrue(brief_path.exists())
             self.assertTrue(os.path.islink("GEMINI.md"))
 
+    def test_init_creates_all_adapter_root_symlinks(self):
+        """init with default --primary claude creates root symlinks for all adapters (#120)."""
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(cli, ["init"])
+            self.assertEqual(result.exit_code, 0)
+            self.assertTrue(os.path.islink("CLAUDE.md"))
+            self.assertIn("claude", os.readlink("CLAUDE.md"))
+            self.assertTrue(os.path.islink("AGENTS.md"))
+            self.assertIn("codex", os.readlink("AGENTS.md"))
+            self.assertTrue(os.path.islink("CODEX.md"))
+            self.assertIn("codex", os.readlink("CODEX.md"))
+            self.assertTrue(os.path.islink("GEMINI.md"))
+            self.assertIn("gemini", os.readlink("GEMINI.md"))
+
     def test_adapter_add_skips_non_symlink_root_file(self):
         """adapter add does not clobber an existing regular-file AGENTS.md."""
         with self.runner.isolated_filesystem():
             self.runner.invoke(cli, ["init", "--primary", "claude"])
-            # Create a real file at AGENTS.md
+            # Replace the symlink created by init with a real file
+            if os.path.islink("AGENTS.md"):
+                os.unlink("AGENTS.md")
             Path("AGENTS.md").write_text("# Custom content\n")
             result = self.runner.invoke(cli, ["adapter", "add", "codex"])
             self.assertEqual(result.exit_code, 0)

--- a/src/tests/test_integration_stress.py
+++ b/src/tests/test_integration_stress.py
@@ -96,13 +96,14 @@ class TestInitDefaultPrimary:
             target = os.readlink("CLAUDE.md")
             assert "claude" in target and "brief.md" in target
 
-    def test_non_primary_root_files_absent(self, runner):
-        """Only the primary CLI's root files are created on init."""
+    def test_all_adapter_root_files_created(self, runner):
+        """init creates root symlinks for all adapters since all briefs compile (#120)."""
         with runner.isolated_filesystem():
             runner.invoke(cli, ["init"])
-            assert not Path("AGENTS.md").exists()
-            assert not Path("GEMINI.md").exists()
-            assert not Path("CODEX.md").exists()
+            assert Path("AGENTS.md").is_symlink()
+            assert Path("CODEX.md").is_symlink()
+            assert Path("GEMINI.md").is_symlink()
+            assert Path("CLAUDE.md").is_symlink()
 
     def test_folder_symlinks_all_created(self, runner):
         with runner.isolated_filesystem():
@@ -179,10 +180,13 @@ class TestInitAlternatePrimary:
             assert Path("CODEX.md").is_symlink()
             assert "codex" in os.readlink("CODEX.md")
 
-    def test_codex_primary_omits_claude_md(self, runner):
+    def test_codex_primary_creates_all_root_files(self, runner):
+        """--primary codex still creates CLAUDE.md and GEMINI.md (all briefs compile)."""
         with runner.isolated_filesystem():
             runner.invoke(cli, ["init", "--primary", "codex"])
-            assert not Path("CLAUDE.md").exists()
+            assert Path("CLAUDE.md").is_symlink()
+            assert Path("AGENTS.md").is_symlink()
+            assert Path("GEMINI.md").is_symlink()
 
     def test_codex_brief_no_commands_section(self, runner):
         """Codex format omits commands — they'd need / prefix which Codex doesn't use."""
@@ -197,11 +201,13 @@ class TestInitAlternatePrimary:
             assert Path("GEMINI.md").is_symlink()
             assert "gemini" in os.readlink("GEMINI.md")
 
-    def test_gemini_primary_omits_claude_agents_md(self, runner):
+    def test_gemini_primary_creates_all_root_files(self, runner):
+        """--primary gemini still creates CLAUDE.md and AGENTS.md (all briefs compile)."""
         with runner.isolated_filesystem():
             runner.invoke(cli, ["init", "--primary", "gemini"])
-            assert not Path("CLAUDE.md").exists()
-            assert not Path("AGENTS.md").exists()
+            assert Path("CLAUDE.md").is_symlink()
+            assert Path("AGENTS.md").is_symlink()
+            assert Path("GEMINI.md").is_symlink()
 
     def test_unknown_primary_fails(self, runner):
         with runner.isolated_filesystem():
@@ -297,6 +303,9 @@ class TestAdapterAdd:
         """A real file at AGENTS.md is never clobbered by adapter add codex."""
         with runner.isolated_filesystem():
             runner.invoke(cli, ["init", "--primary", "claude"])
+            # Replace the symlink created by init with a real file
+            if Path("AGENTS.md").is_symlink():
+                Path("AGENTS.md").unlink()
             Path("AGENTS.md").write_text("# Custom\n")
             r = runner.invoke(cli, ["adapter", "add", "codex"])
             assert r.exit_code == 0
@@ -653,15 +662,14 @@ class TestFullLifecycle:
                     f"lifecycle-agent missing from {adapter} after wrap"
 
     def test_codex_then_claude_activation(self, runner):
-        """Start with codex primary, then add claude mid-project."""
+        """Start with codex primary — all root files exist; claude symlink verified."""
         with runner.isolated_filesystem():
             runner.invoke(cli, ["init", "--primary", "codex"])
             assert Path("AGENTS.md").is_symlink()
-            assert not Path("CLAUDE.md").exists()
-            runner.invoke(cli, ["adapter", "add", "claude"])
+            # CLAUDE.md is created on init (all adapters compile)
             assert Path("CLAUDE.md").is_symlink()
             assert "claude" in os.readlink("CLAUDE.md")
-            # AGENTS.md still points to codex
+            # AGENTS.md points to codex
             assert "codex" in os.readlink("AGENTS.md")
 
 

--- a/src/tests/test_librarian_lifecycle.py
+++ b/src/tests/test_librarian_lifecycle.py
@@ -8,7 +8,7 @@ import zipfile
 from pathlib import Path
 
 from agent_gen.librarian import (
-    Librarian, MANIFEST_FILE, HARNESS_ROOT, _safe_extract,
+    Librarian, MANIFEST_FILE, HARNESS_ROOT, CONTEXT_FILE, _safe_extract,
 )
 
 class TestLibrarianLifecycle(unittest.TestCase):
@@ -397,6 +397,55 @@ class TestFormatSwitchLibrarian(unittest.TestCase):
             Librarian._migrate_root_symlinks(str(root))
             # Symlink should still point to AgentFactory.md
             self.assertIn("AgentFactory.md", os.readlink(str(legacy_link)))
+
+
+    def test_update_harness_files_injects_skills_registry_when_marker_absent(self):
+        """update_harness_files appends @skills-registry block to README when marker absent (#121)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root)
+            # README without @skills-registry marker
+            readme = root / "README.md"
+            readme.write_text("# My Project\n\nSome content.\n", encoding="utf-8")
+            # Also create required AgentFactory.md
+            (root / HARNESS_ROOT / CONTEXT_FILE).write_text(
+                "<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+                "<!-- @skills-registry:start -->\n<!-- @skills-registry:end -->\n",
+                encoding="utf-8",
+            )
+            (root / HARNESS_ROOT / "agent-manifest.json").write_text(
+                '{"factory":"AF","agents":{}}', encoding="utf-8"
+            )
+            self._add_skill(root, "my-skill", "A test skill")
+            Librarian.update_harness_files(str(root))
+            content = readme.read_text(encoding="utf-8")
+            self.assertIn("<!-- @skills-registry:start -->", content)
+            self.assertIn("my-skill", content)
+
+    def test_update_harness_files_updates_skills_registry_when_marker_present(self):
+        """update_harness_files replaces existing @skills-registry block in README."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root)
+            readme = root / "README.md"
+            readme.write_text(
+                "# My Project\n\n"
+                "<!-- @skills-registry:start -->\nold content\n<!-- @skills-registry:end -->\n",
+                encoding="utf-8",
+            )
+            (root / HARNESS_ROOT / CONTEXT_FILE).write_text(
+                "<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+                "<!-- @skills-registry:start -->\n<!-- @skills-registry:end -->\n",
+                encoding="utf-8",
+            )
+            (root / HARNESS_ROOT / "agent-manifest.json").write_text(
+                '{"factory":"AF","agents":{}}', encoding="utf-8"
+            )
+            self._add_skill(root, "updated-skill", "Updated")
+            Librarian.update_harness_files(str(root))
+            content = readme.read_text(encoding="utf-8")
+            self.assertNotIn("old content", content)
+            self.assertIn("updated-skill", content)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- **#120** — `init` now creates root MD symlinks for **all** adapters (`CLAUDE.md`, `AGENTS.md`, `CODEX.md`, `GEMINI.md`) instead of only the primary adapter. Since all three adapter dirs are created by `init` and all briefs compile, every CLI tool gets its root file on first run.
- **#121** — `update_harness_files` now injects a `@skills-registry` block into `README.md` when the marker is absent, matching the existing `else` branch for `@agent-registry`. Previously the skills section was silently skipped.
- Pre-existing test crash (`ValueError` on `result.stderr` property) also fixed.

## Root causes
- `cli.py:260` looped `primary_config["root_files"]` — changed to iterate all `_FORMAT_REGISTRY` entries
- `librarian.py:1051` had `if` but no `else` for the skills-registry block — added `else` branch

## Test plan
- [ ] 181 tests pass (`python3 -m pytest src/tests/ -q`)
- [ ] New test `test_init_creates_all_adapter_root_symlinks` verifies CLAUDE/AGENTS/CODEX/GEMINI all created
- [ ] Two new lifecycle tests verify skills-registry injection (absent marker) and update (present marker)

Closes #120
Closes #121