### PR TITLE
feat: wire AgentFactory.md as compiled master brief + preamble injection

### DIFF
--- a/.ai/AgentFactory.md
+++ b/.ai/AgentFactory.md
@@ -73,3 +73,20 @@ Claude, Codex, and Gemini share the same `.ai/` directory for shared context wit
 - **test-claude-agent**: AgentFactory-powered agent demonstrating a minimal Claude-native agent layout. (See: `.ai/agents/test-claude-agent/docs/CLAUDE.md`)
 - **test-intel-agent**: AgentFactory-powered agent demonstrating intelligence-layer features: dependency detection and skill manifest parsing. (See: `.ai/agents/test-intel-agent/docs/CLAUDE.md`)
 <!-- @agent-registry:end -->
+
+<!-- @commands-start -->
+## Commands
+- `/completeness-check` — <!-- version: 1.0.0 -->
+- `/git-workflow` — <!-- version: 1.0.0 -->
+<!-- @commands-end -->
+
+<!-- @rules-start -->
+## Behavior Rules
+- **Quiet Mode:** Prefer quiet flags to reduce output noise.
+- **Version Markers:** Every `.md` file MUST have a version marker.
+- **Branches:** Create a feature branch for every task.
+- **Create at init:** Every project must have `.ai/memory/milestones.md` scaffolded by `agentfactory-gen init`. It is the single source of truth for all issue and work-item tracking.
+- **Secrets:** Never log, print, or commit API keys or secrets.
+- **Skill Briefing:** Skill metadata used in compiled briefs must stay brief-safe: keep `description` to a short summary line and `triggers` or `when_to_use` to a short invocation hint instead of procedural detail.
+- **Coverage:** Aim for 80%+ test coverage for new logic.
+<!-- @rules-end -->

--- a/.ai/adapters/claude/brief.md
+++ b/.ai/adapters/claude/brief.md
@@ -16,6 +16,7 @@ AgentFactory project. All adapters share the same harness context.
 
 Shared context (read these to understand the project):
 
+  .ai/AgentFactory.md         ← project overview + master compiled brief
   .ai/skills/               ← skill specs (symlinked per adapter)
   .ai/rules/                ← behavior rules compiled into this brief
   .ai/agent-manifest.json   ← global agent registry
@@ -29,6 +30,53 @@ All adapter briefs (same project, different CLI):
 
 If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
 
+## Project Context
+
+<!-- version: 2.1.0 -->
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+AgentFactory is a lightweight Python-based CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents as **Portable Units**. Source lives in `src/agent_gen/`; tests in `src/tests/`.
+
+## Development Commands
+
+```bash
+# Install (editable)
+pip install -e .
+
+# Run all tests
+pytest
+
+# Run a single test file
+pytest src/tests/test_cli.py
+
+# Run a single test by name
+pytest src/tests/test_cli.py::TestCliCommands::test_e2e_lifecycle
+```
+
+## Architecture
+
+### Unified Harness (`.ai/`)
+All harness content lives under `.ai/`. Root files are symlinks:
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CODEX.md` → `.ai/AgentFactory.md` (this file)
+- `.claude` → `.ai/adapters/claude` | `.gemini` → `.ai/adapters/gemini` | `.codex` → `.ai/adapters/codex`
+
+Internal layout:
+1. `.ai/rules/`: Enforceable project constraints (git, testing, docs, cli, security).
+2. `.ai/commands/`: Slash commands (Claude) and prompt templates (Codex).
+3. `.ai/skills/`: Reusable deep-context workflows. Accessible to Claude via `.claude/skills/`.
+4. `.ai/agents/`: Deployed agent directories — each follows the **5-Directory Standard**: `skills/` · `commands/` · `docs/` · `scripts/` · `orchestration/`.
+5. `.ai/memory/`: Project state and context.
+6. `.ai/adapters/`: Per-CLI config + capability symlinks (commands→, skills→, tools→).
+
+### Core Engine: The Librarian (`src/agent_gen/librarian.py`)
+Central class driving every lifecycle operation. Key responsibilities:
+- **Manifest Integrity:** Load/validate/save `agent-manifest.json` per agent.
+- **Lifecycle:** `init`, `sync`, `audit`, `wrap`, `unpack`, `import_skill`, `migrate` (retrofit), `uninstall`.
+- **Global registry:** `sync_to_global`, `register_in_project`, `update_harness_files` keep `.ai/AgentFactory.md` and `.ai/agent-manifest.json` in sync across all agents.
+- **Intelligence Layer:** `_detect_dependencies` (AST-based Python import parsing + `
+
 ## Available Skills
 
 | Skill | When to invoke | Path |
@@ -38,6 +86,7 @@ If switching CLI: run `agentfactory-gen brief` to recompile all active adapter b
 | issue-tracker |  | `.claude/skills/issue-tracker/SKILL.md` |
 
 ## Commands
+- `/completeness-check` — <!-- version: 1.0.0 -->
 - `/git-workflow` — <!-- version: 1.0.0 -->
 
 ## Registered Agents

--- a/.ai/adapters/codex/brief.md
+++ b/.ai/adapters/codex/brief.md
@@ -16,6 +16,7 @@ AgentFactory project. All adapters share the same harness context.
 
 Shared context (read these to understand the project):
 
+  .ai/AgentFactory.md         ← project overview + master compiled brief
   .ai/skills/               ← skill specs (symlinked per adapter)
   .ai/rules/                ← behavior rules compiled into this brief
   .ai/agent-manifest.json   ← global agent registry
@@ -28,6 +29,48 @@ All adapter briefs (same project, different CLI):
   gemini   GEMINI.md            → .ai/adapters/gemini/brief.md
 
 If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
+
+## Project Context
+
+<!-- version: 2.1.0 -->
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+AgentFactory is a lightweight Python-based CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents as **Portable Units**. Source lives in `src/agent_gen/`; tests in `src/tests/`.
+
+## Development Commands
+
+```bash
+# Install (editable)
+pip install -e .
+
+# Run all tests
+pytest
+
+# Run a single test file
+pytest src/tests/test_cli.py
+
+# Run a single test by name
+pytest src/tests/test_cli.py::TestCliCommands::test_e2e_lifecycle
+```
+
+## Architecture
+
+### Unified Harness (`.ai/`)
+All harness content lives under `.ai/`. Root files are symlinks:
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CODEX.md` → `.ai/AgentFactory.md` (this file)
+- `.claude` → `.ai/adapters/claude` | `.gemini` → `.ai/adapters/gemini` | `.codex` → `.ai/adapters/codex`
+
+Internal layout:
+1. `.ai/rules/`: Enforceable project constraints (git, testing, docs, cli, security).
+2. `.ai/commands/`: Slash commands (Claude) and prompt templates (Codex).
+3. `.ai/skills/`: Reusable deep-context workflows. Accessible to Claude via `.claude/skills/`.
+4. `.ai/agents/`: Deployed agent directories — each follows the **5-Directory Standard**: `skills/` · `commands/` · `docs/` · `scripts/` · `orchestration/`.
+5. `.ai/memory/`: Project state and context.
+6. `.ai/adapters/`: Per-CLI config + capability symlinks (commands→, skills→, tools→).
+
+<!-- ⚠ context truncated: 2035 → 2000 chars for 95% budget. -->
 
 ## Available Skills
 

--- a/.ai/adapters/gemini/brief.md
+++ b/.ai/adapters/gemini/brief.md
@@ -16,6 +16,7 @@ AgentFactory project. All adapters share the same harness context.
 
 Shared context (read these to understand the project):
 
+  .ai/AgentFactory.md         ← project overview + master compiled brief
   .ai/skills/               ← skill specs (symlinked per adapter)
   .ai/rules/                ← behavior rules compiled into this brief
   .ai/agent-manifest.json   ← global agent registry
@@ -28,6 +29,53 @@ All adapter briefs (same project, different CLI):
   gemini   GEMINI.md            → .ai/adapters/gemini/brief.md ← YOU ARE HERE
 
 If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.
+
+## Project Context
+
+<!-- version: 2.1.0 -->
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+AgentFactory is a lightweight Python-based CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents as **Portable Units**. Source lives in `src/agent_gen/`; tests in `src/tests/`.
+
+## Development Commands
+
+```bash
+# Install (editable)
+pip install -e .
+
+# Run all tests
+pytest
+
+# Run a single test file
+pytest src/tests/test_cli.py
+
+# Run a single test by name
+pytest src/tests/test_cli.py::TestCliCommands::test_e2e_lifecycle
+```
+
+## Architecture
+
+### Unified Harness (`.ai/`)
+All harness content lives under `.ai/`. Root files are symlinks:
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `CODEX.md` → `.ai/AgentFactory.md` (this file)
+- `.claude` → `.ai/adapters/claude` | `.gemini` → `.ai/adapters/gemini` | `.codex` → `.ai/adapters/codex`
+
+Internal layout:
+1. `.ai/rules/`: Enforceable project constraints (git, testing, docs, cli, security).
+2. `.ai/commands/`: Slash commands (Claude) and prompt templates (Codex).
+3. `.ai/skills/`: Reusable deep-context workflows. Accessible to Claude via `.claude/skills/`.
+4. `.ai/agents/`: Deployed agent directories — each follows the **5-Directory Standard**: `skills/` · `commands/` · `docs/` · `scripts/` · `orchestration/`.
+5. `.ai/memory/`: Project state and context.
+6. `.ai/adapters/`: Per-CLI config + capability symlinks (commands→, skills→, tools→).
+
+### Core Engine: The Librarian (`src/agent_gen/librarian.py`)
+Central class driving every lifecycle operation. Key responsibilities:
+- **Manifest Integrity:** Load/validate/save `agent-manifest.json` per agent.
+- **Lifecycle:** `init`, `sync`, `audit`, `wrap`, `unpack`, `import_skill`, `migrate` (retrofit), `uninstall`.
+- **Global registry:** `sync_to_global`, `register_in_project`, `update_harness_files` keep `.ai/AgentFactory.md` and `.ai/agent-manifest.json` in sync across all agents.
+- **Intelligence Layer:** `_detect_dependencies` (AST-based Python import parsing + `
 
 ## Available Tools
 

--- a/.ai/memory/milestones.md
+++ b/.ai/memory/milestones.md
@@ -1,5 +1,5 @@
 # Milestones
-<!-- version: 1.7.5 -->
+<!-- version: 1.7.6 -->
 
 Living traceability matrix for all AgentFactory GitHub issues.
 Update this file on every PR merge and release (see git-versioning SKILL.md Step 8.5).
@@ -155,6 +155,8 @@ Issues below are tracked in the private webapp repo as of 2026-04-21.
 | #120 | bug: init creates root MD symlinks for primary adapter only | bug | done | fix/120-121-harness-init-gaps | #123 | 47f8e46 | — |
 | #121 | bug: update_harness_files skips @skills-registry injection in README when marker absent | bug | done | fix/120-121-harness-init-gaps | #123 | 47f8e46 | — |
 | #114 | feat[P2]: auth backend — FastAPI OAuth server + JWT sessions + license validation | platform | done | feature/114-auth-backend | #124 | 39d0e8c | — |
+| #125 | feat: AgentFactory.md master brief + preamble injection into all adapter briefs | feature | in-progress | feature/agentfactory-md-master-brief | #125 | c31417b | — |
+| #126 | feat: extend completeness oracle to project-context preamble truncation | feature | pending | — | — | — | — |
 
 ## Pending (legacy / non-platform)
 

--- a/.ai/memory/milestones.md
+++ b/.ai/memory/milestones.md
@@ -1,5 +1,5 @@
 # Milestones
-<!-- version: 1.7.6 -->
+<!-- version: 1.7.7 -->
 
 Living traceability matrix for all AgentFactory GitHub issues.
 Update this file on every PR merge and release (see git-versioning SKILL.md Step 8.5).
@@ -155,7 +155,7 @@ Issues below are tracked in the private webapp repo as of 2026-04-21.
 | #120 | bug: init creates root MD symlinks for primary adapter only | bug | done | fix/120-121-harness-init-gaps | #123 | 47f8e46 | — |
 | #121 | bug: update_harness_files skips @skills-registry injection in README when marker absent | bug | done | fix/120-121-harness-init-gaps | #123 | 47f8e46 | — |
 | #114 | feat[P2]: auth backend — FastAPI OAuth server + JWT sessions + license validation | platform | done | feature/114-auth-backend | #124 | 39d0e8c | — |
-| #125 | feat: AgentFactory.md master brief + preamble injection into all adapter briefs | feature | in-progress | feature/agentfactory-md-master-brief | #125 | c31417b | — |
+| #125 | feat: AgentFactory.md master brief + preamble injection into all adapter briefs | feature | done | feature/agentfactory-md-master-brief | #125 | c4cd5a2 | v2.8.0 |
 | #126 | feat: extend completeness oracle to project-context preamble truncation | feature | pending | — | — | — | — |
 
 ## Pending (legacy / non-platform)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,api]"
 
       - name: Run tests with coverage
         run: pytest -m "not integration" --cov=agent_gen --cov-report=term-missing --cov-fail-under=80
@@ -60,7 +60,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,api]"
 
       - name: Run integration stress tests
         run: pytest -m integration -v --no-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
-<!-- version: 2.6.1 -->
+<!-- version: 2.8.0 -->
+
+## [v2.8.0] - 2026-04-22
+
+### Added
+- **AgentFactory.md as full master compiled brief**: `agentfactory-gen brief` now upserts
+  `<!-- @commands-start/end -->` and `<!-- @rules-start/end -->` sections into
+  `.ai/AgentFactory.md`, giving it the same richness as any per-adapter brief (#125)
+- **`## Project Context` injected into every adapter brief**: every compiled brief carries
+  the human-written preamble from `.ai/AgentFactory.md`, budget-fitted per adapter
+  (claude/gemini: 4 000 chars, codex: 2 000 chars with truncation warning) (#125)
+- `context_char_limit` per-adapter config key in `_FORMAT_REGISTRY`
+- `_collect_project_context()` — extracts preamble before first `<!-- @` marker, strips H1
+- `_fit_context_to_budget()` — paragraph-boundary truncation with warning HTML comment;
+  adds completeness-check hint when `AGENTFACTORY_LICENSE_KEY` is set
+- `.ai/AgentFactory.md` now listed in the Harness Identity Block shared-context section
+- `docs/FEATURE-AGENTFACTORY-MD-BRIEF.md` — complete feature doc with workflow diagrams
+  and gap analysis
+
+### Fixed
+- `docs/WORKFLOWS.md` diagram 1 was architecturally stale since FormatSwitch (#96):
+  showed root symlinks pointing to `AgentFactory.md` instead of compiled briefs (#125)
+- README described `AgentFactory.md` as "legacy + sync target" — corrected to "master
+  compiled brief"
+
+### Tests
+- 7 new tests in `test_librarian_lifecycle.py` (203 total): context injection,
+  H1/registry stripping, missing-AF.md graceful compile, codex truncation,
+  claude no-truncation, AgentFactory.md rules+commands upsert, harness identity reference
+
+---
+
+## [v2.7.0] - 2026-04-22
+
+### Added
+- **FastAPI auth backend** (#114): GitHub OAuth flow, JWT httpOnly cookie sessions,
+  SQLite default (swappable to PostgreSQL via `DATABASE_URL` env var), license key
+  validation endpoint
+- `src/agent_gen/api/` — new module: `main.py`, `db.py`, `jwt_utils.py`, `models.py`,
+  `deps.py`, `routers/auth.py`, `routers/license.py`
+- `agentfactory-api` CLI entry point (uvicorn-backed dev server)
+- `api` extras in `pyproject.toml`: `fastapi`, `uvicorn[standard]`, `python-jose`, `httpx`, `pydantic`
+- `docker-compose.yml` + `Dockerfile.api` — one-command full-stack local dev (API + PostgreSQL)
+- `.env.example` — documents all environment variables
+- `api/openapi.json` — committed OpenAPI spec (webapp's authoritative type source)
+- `docs/MULTI-REPO-WORKFLOW.md` — two-repo development protocol, type generation, wave map
+
+### Tests
+- `src/tests/test_api_auth.py` — 15 tests: JWT, license validation, /auth/me, /auth/logout, /health
+
+---
+
+## [v2.6.0] - 2026-04-22
+
+### Fixed
+- `agentfactory-gen init` now creates root symlinks for **all** registered adapters, not
+  only the primary one (#120). Previously `init --primary codex` would create `AGENTS.md`
+  and `CODEX.md` but leave `CLAUDE.md` and `GEMINI.md` absent.
+- `update_harness_files()` now injects `## Available Skills` into files that lack the
+  `<!-- @skills-registry:start -->` marker (#121). Previously the injection was silently
+  skipped, leaving READMEs without a skills section on first run.
+
+### Tests
+- Updated 5 integration stress tests that encoded the old single-adapter root-file behavior
+- Added 2 lifecycle tests for skills-registry injection: marker-absent and marker-present
+
+---
 
 ## [v2.5.2] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AgentFactory
-<!-- version: 2.7.0 -->
+<!-- version: 2.8.0 -->
 
 A Python CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents
 as portable, framework-agnostic units. The web platform lives at
@@ -23,7 +23,7 @@ project/
 ├── .codex     → .ai/adapters/codex/
 ├── .gemini    → .ai/adapters/gemini/
 └── .ai/
-    ├── AgentFactory.md          ← combined brief (legacy + sync target)
+    ├── AgentFactory.md          ← master compiled brief (preamble + registries + rules + commands)
     ├── agent-manifest.json      ← global agent registry
     ├── config/
     │   └── completeness.json    ← per-adapter skill completeness thresholds
@@ -41,9 +41,14 @@ project/
 ```
 
 Every adapter brief starts with a **Harness Identity Block** — a standard section
-that maps all adapter briefs and shared context paths. Any agent picking up the
-project for the first time (or after a CLI swap) can navigate the full harness
-immediately.
+that maps all adapter briefs and shared context paths, including a direct reference
+to `.ai/AgentFactory.md`. Any agent picking up the project for the first time (or
+after a CLI swap) can navigate the full harness immediately.
+
+Every adapter brief also carries a **Project Context** section: the human-written
+preamble from `.ai/AgentFactory.md`, budget-fitted per adapter (claude/gemini: 4 000
+chars, codex: 2 000 chars). This closes the context gap that existed when switching
+CLIs mid-project.
 
 Each agent under `.ai/agents/<name>/` follows the **5-Directory Standard**:
 `skills/` · `commands/` · `docs/` · `scripts/` · `orchestration/`
@@ -165,6 +170,32 @@ can navigate to the other briefs after a CLI swap.
 
 Recompile all active briefs: `agentfactory-gen brief`
 
+### Project Context Injection & Master Brief
+
+Every adapter brief gets a `## Project Context` section automatically — the
+human-written preamble from `.ai/AgentFactory.md`, trimmed to fit the adapter's
+character budget:
+
+| Adapter | Context limit | Behaviour on overflow |
+|---------|--------------|----------------------|
+| Claude | 4 000 chars | Full preamble |
+| Gemini | 4 000 chars | Full preamble |
+| Codex | 2 000 chars | Truncated at paragraph boundary + `<!-- ⚠ context truncated -->` comment |
+
+`AgentFactory.md` is also compiled as a **full master brief**: `agentfactory-gen brief`
+upserts `<!-- @commands-start/end -->` and `<!-- @rules-start/end -->` sections so it
+has the same richness as any adapter brief. Reading it directly gives a complete
+picture of the project.
+
+```bash
+# After editing your project overview in .ai/AgentFactory.md:
+agentfactory-gen brief
+# → All adapter briefs updated with new preamble
+# → AgentFactory.md updated with latest rules + commands
+```
+
+Full reference: [`docs/FEATURE-AGENTFACTORY-MD-BRIEF.md`](docs/FEATURE-AGENTFACTORY-MD-BRIEF.md)
+
 ### Skill Completeness Oracle
 
 A two-phase Claude Haiku oracle that verifies a trimmed `SKILL.md` preserves all
@@ -256,6 +287,7 @@ Branch protection on `dev` requires **Tests + Coverage** to pass before merge.
 | [`docs/SKILL-COMPLETENESS-SPEC.md`](docs/SKILL-COMPLETENESS-SPEC.md) | Two-phase oracle, CLI reference, all integration points |
 | [`docs/HOWTO.md`](docs/HOWTO.md) | Workflow diagrams: deploy, retrofit, wrap, import, uninstall |
 | [`docs/FEATURE-AUTH.md`](docs/FEATURE-AUTH.md) | GitHub + Google OAuth system: states, API contract, plan gating |
+| [`docs/FEATURE-AGENTFACTORY-MD-BRIEF.md`](docs/FEATURE-AGENTFACTORY-MD-BRIEF.md) | Master brief & project context injection: workflow diagrams, gap analysis, CLI switch walkthrough |
 | [`docs/FEATURE-HARNESS-IDENTITY.md`](docs/FEATURE-HARNESS-IDENTITY.md) | Cross-adapter navigation block: how it works, swap walkthrough |
 | [`docs/FEATURE-DOC-TEMPLATE.md`](docs/FEATURE-DOC-TEMPLATE.md) | Blank template — every new feature ships one of these |
 | [`docs/ISSUE-PRIORITY.md`](docs/ISSUE-PRIORITY.md) | Live issue priority + wave map (auto-regenerated on every merge) |

--- a/README.md
+++ b/README.md
@@ -285,3 +285,10 @@ Features that introduce new public behaviour must ship with a `docs/FEATURE-<nam
 - **test-claude-agent**: AgentFactory-powered agent demonstrating a minimal Claude-native agent layout. (See: `.ai/agents/test-claude-agent/docs/CLAUDE.md`)
 - **test-intel-agent**: AgentFactory-powered agent demonstrating intelligence-layer features: dependency detection and skill manifest parsing. (See: `.ai/agents/test-intel-agent/docs/CLAUDE.md`)
 <!-- @agent-registry:end -->
+
+## Available Skills
+<!-- @skills-registry:start -->
+- **diff-visualizer**: Generates HTML diff reports visualizing what changed between two versions of the repo. (See: `.ai/skills/diff-visualizer/SKILL.md`)
+- **git-versioning**: Manages project-wide versioning and repo-state.md updates. (See: `.ai/skills/git-versioning/SKILL.md`)
+- **issue-tracker**: Regenerates the issue priority report and dependency matrix from live GitHub data. (See: `.ai/skills/issue-tracker/SKILL.md`)
+<!-- @skills-registry:end -->

--- a/docs/FEATURE-AGENTFACTORY-MD-BRIEF.md
+++ b/docs/FEATURE-AGENTFACTORY-MD-BRIEF.md
@@ -1,0 +1,351 @@
+# AgentFactory.md — Master Brief & Project Context Injection
+<!-- version: 1.0.0 -->
+
+Issue: #125 · Every adapter brief now carries project context; AgentFactory.md compiled as full master brief
+
+---
+
+## 1. Problem Statement
+
+FormatSwitch (#96) was a major step forward: it gave each CLI a compiled brief in its
+own format. But it introduced a silent regression. Before FormatSwitch, all root files
+(`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) were symlinks to `.ai/AgentFactory.md` — the
+developer's source of truth. After FormatSwitch they pointed to adapter-specific
+compiled briefs that had skills, rules, and agents, but **zero project context**.
+
+```
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │  THE GAP                                                                │
+  │                                                                         │
+  │  Developer starts on Claude. Claude reads a brief with architecture,   │
+  │  dev commands, and project overview.                                   │
+  │                                                                         │
+  │  Developer switches to Codex mid-project.                              │
+  │  Codex reads AGENTS.md — skills ✓, rules ✓, agents ✓                  │
+  │                         — architecture ✗, dev commands ✗, overview ✗  │
+  │                                                                         │
+  │  The agent is context-blind. It will ask questions, make wrong         │
+  │  assumptions, and produce work that doesn't fit the project.           │
+  └────────────────────────────────────────────────────────────────────────┘
+```
+
+At the same time, `.ai/AgentFactory.md` itself was never compiled — it received
+`@agent-registry` and `@skills-registry` injections from `update_harness_files()`,
+but never got the rules or commands sections that every adapter brief had. A developer
+reading it directly would miss half the compiled context.
+
+---
+
+## 2. Solution Overview
+
+Three changes shipped together:
+
+| Phase | What | Why |
+|-------|------|-----|
+| 1 | Extract preamble from `AgentFactory.md` and inject it as `## Project Context` into every adapter brief, budget-fitted to each adapter's character limit | Every CLI gets project context on CLI swap without any manual step |
+| 2 | Compile `AgentFactory.md` as a full master brief — upsert `@commands` + `@rules` sections | AgentFactory.md is now as rich as any adapter brief; single place to read everything |
+| 3 | List `.ai/AgentFactory.md` explicitly in the Harness Identity Block shared-context section | Any agent following the identity block navigation now finds the master document |
+
+---
+
+## 3. Complete Workflow
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║              AgentFactory — Complete Development Workflow                    ║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║  ① Harness Layout  ·  ② Compilation Pipeline  ·  ③ Brief Anatomy           ║
+║  ④ CLI Switch Scenario  ·  ⑤ Development Loop                               ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+
+
+┌─── ① HARNESS LAYOUT (.ai/) ────────────────────────────────────────────────┐
+│                                                                              │
+│  .ai/                                                                        │
+│  ├── AgentFactory.md      ← master brief                                    │
+│  │     preamble (human-written)                                              │
+│  │     <!-- @agent-registry -->      auto-managed by update_harness_files   │
+│  │     <!-- @skills-registry -->     auto-managed by update_harness_files   │
+│  │     <!-- @commands-start/end -->  compiled by agentfactory-gen ← NEW     │
+│  │     <!-- @rules-start/end -->     compiled by agentfactory-gen ← NEW     │
+│  ├── agent-manifest.json  ← global agent registry                           │
+│  ├── adapters/                                                               │
+│  │   ├── claude/                                                             │
+│  │   │   ├── brief.md  ←── CLAUDE.md (root symlink)                         │
+│  │   │   ├── skills/   ──► ../../skills                                     │
+│  │   │   └── commands/ ──► ../../commands                                   │
+│  │   ├── codex/                                                              │
+│  │   │   ├── brief.md  ←── AGENTS.md · CODEX.md (root symlinks)             │
+│  │   │   ├── skills/   ──► ../../skills                                     │
+│  │   │   └── prompts/  ──► ../../commands                                   │
+│  │   └── gemini/                                                             │
+│  │       ├── brief.md  ←── GEMINI.md (root symlink)                         │
+│  │       └── tools/    ──► ../../skills                                     │
+│  ├── skills/    SKILL.md + skill-manifest.json per skill                    │
+│  ├── rules/     *.md behavior constraints                                   │
+│  ├── commands/  *.md slash-commands / prompt templates                      │
+│  ├── agents/    deployed agent dirs (5-dir standard)                        │
+│  └── memory/                                                                 │
+│      └── milestones.md  ← single source of truth for issues                 │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+
+┌─── ② COMPILATION PIPELINE  (agentfactory-gen brief) ───────────────────────┐
+│                                                                              │
+│  Input sources                          _compile_adapter_briefs()           │
+│  ─────────────────────                  ──────────────────────────          │
+│                                                                              │
+│  .ai/skills/         ──┐                                                     │
+│  .ai/agents/         ──┤──► data = { skills, agents, commands, rules,       │
+│  .ai/commands/       ──┤             project_context }  ← NEW               │
+│  .ai/rules/          ──┤                    │                                │
+│  AgentFactory.md     ──┘  (preamble only)   │  _render_brief() per adapter  │
+│        ▲                                    │                                │
+│        │ also WRITTEN back                  └──────┬──────────┬─────────┐   │
+│        │ _compile_agentfactory_md() ← NEW          ▼          ▼         ▼   │
+│        │ upserts @commands + @rules           ┌────────┐ ┌────────┐ ┌──────┐│
+│        └──────────────────────────────────────│ claude │ │ codex  │ │gemini││
+│                                               │ 4000 ch│ │ 2000 ch│ │4000ch││
+│                                               │brief.md│ │brief.md│ │brief ││
+│                                               └────────┘ └────────┘ └──────┘│
+└──────────────────────────────────────────────────────────────────────────────┘
+
+
+┌─── ③ BRIEF ANATOMY (per adapter) ──────────────────────────────────────────┐
+│                                                                              │
+│  AgentFactory.md                      Compiled adapter brief                │
+│  ┌───────────────────────────┐        ┌─────────────────────────────────┐   │
+│  │ # AgentFactory            │        │ # Intelligence Brief — <CLI>    │   │
+│  │ Overview, architecture,   │──┐     │ <!-- @compiled-by: af-gen -->   │   │
+│  │ dev commands, notes…      │  │     ├─────────────────────────────────┤   │
+│  │  ← preamble (extracted)   │  │     │ ## Harness                      │   │
+│  ├───────────────────────────┤  │     │   .ai/AgentFactory.md  ← ref    │   │
+│  │ <!-- @agent-registry -->  │  │     │   nav block + all adapter links │   │
+│  │ <!-- @skills-registry --> │  │     ├─────────────────────────────────┤   │
+│  ├───────────────────────────┤  └────►│ ## Project Context  ← NEW       │   │
+│  │ <!-- @commands-start -->  │        │   budget-fit preamble injected  │   │
+│  │  …commands…   ← compiled  │        │   claude · gemini : ≤ 4000 ch   │   │
+│  │ <!-- @commands-end -->    │        │   codex           : ≤ 2000 ch   │   │
+│  ├───────────────────────────┤        │   (truncated → ⚠ html comment) │   │
+│  │ <!-- @rules-start -->     │        ├─────────────────────────────────┤   │
+│  │  …rules…      ← compiled  │        │ ## Available Skills             │   │
+│  │ <!-- @rules-end -->       │        │ ## Registered Agents            │   │
+│  └───────────────────────────┘        │ ## Behavior Rules               │   │
+│                                       └─────────────────────────────────┘   │
+│                                                                              │
+│  _collect_project_context()  → strips H1 title, stops at first <!-- @       │
+│  _fit_context_to_budget()    → truncates at paragraph boundary if over limit│
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+
+┌─── ④ CLI SWITCH SCENARIO ──────────────────────────────────────────────────┐
+│                                                                              │
+│  Developer switches Claude → Codex mid-project                              │
+│                                                                              │
+│  ✗ BEFORE (#96 FormatSwitch gap)         ✓ AFTER (this PR, #125)            │
+│  ┌──────────────────────────────┐        ┌──────────────────────────────┐   │
+│  │ AGENTS.md → codex/brief.md  │        │ AGENTS.md → codex/brief.md  │   │
+│  │ ─────────────────────────── │        │ ─────────────────────────── │   │
+│  │ ## Harness (nav only)    ✓  │        │ ## Harness (nav + AF.md) ✓  │   │
+│  │ ## Available Skills      ✓  │        │ ## Project Context  ← NEW   │   │
+│  │ ## Registered Agents     ✓  │        │    arch + cmds (2000 ch max)│   │
+│  │ ## Behavior Rules        ✓  │        │    ⚠ if truncated: warned   │   │
+│  │                              │        │ ## Available Skills      ✓  │   │
+│  │ ✗ no architecture overview   │        │ ## Registered Agents     ✓  │   │
+│  │ ✗ no dev commands            │        │ ## Behavior Rules        ✓  │   │
+│  │ ✗ no project context         │        └──────────────────────────────┘   │
+│  └──────────────────────────────┘                                            │
+│                                                                              │
+│  Run after switch:  agentfactory-gen brief                                  │
+│                     → all briefs recompiled with current preamble           │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+
+
+┌─── ⑤ DEVELOPMENT LOOP ─────────────────────────────────────────────────────┐
+│                                                                              │
+│   ┌──────────────┐    ┌────────────────────────┐    ┌──────────────────┐   │
+│   │  GitHub      │    │  feature branch         │    │  implement       │   │
+│   │  issue       ├───►│  git checkout -b        ├───►│  edit code       │   │
+│   │  opened      │    │  feature/<name>         │    │  add tests       │   │
+│   └──────────────┘    └────────────────────────┘    └────────┬─────────┘   │
+│                                                               │              │
+│                                                               ▼              │
+│                                              ┌────────────────────────────┐ │
+│                                              │  pytest src/tests/ -q      │ │
+│                                              │  ruff check .              │ │
+│                                              │  203+ tests green ✓        │ │
+│                                              └──────────────┬─────────────┘ │
+│                                                             │                │
+│   ┌────────────────────────────┐    ┌──────────────┐       │                │
+│   │  agentfactory-gen brief    │    │  merge PR    │       │                │
+│   │  milestones.md update      │◄───│  → dev       │◄─── gh pr create      │
+│   │  CHANGELOG version bump    │    └──────────────┘                        │
+│   └────────────────────────────┘                                            │
+│                                                                              │
+│  Key rules:                                                                  │
+│  · Every task → feature branch  (never commit directly to dev)              │
+│  · Every .md  → version marker  (<!-- version: x.y.z -->)                  │
+│  · Every new logic → ≥ 80% test coverage                                   │
+│  · Secrets never logged, printed, or committed                              │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Gap Analysis (found during design)
+
+The diagram work that produced this feature exposed six architectural gaps:
+
+### G1 — WORKFLOWS.md diagram 1 was architecturally stale
+The Mermaid overall-architecture diagram showed `CLAUDE.md →|symlink| AgentFactory.md`.
+This was true before FormatSwitch (#96). After it, root files point to compiled adapter
+briefs (`adapters/claude/brief.md`). The diagram was never updated. **Fixed in this PR.**
+
+### G2 — AgentFactory.md described as "legacy + sync target" in README
+After this PR it is the primary master brief — compiled with full rules and commands
+sections on every `agentfactory-gen brief` run. The "legacy" label was misleading.
+**Fixed in this PR.**
+
+### G3 — No project context survived a CLI swap
+The FormatSwitch compilation collected skills/agents/commands/rules but never read
+the preamble of `AgentFactory.md`. A Codex or Gemini agent opening a Claude project
+had zero project context: no architecture, no dev commands, no overview.
+**Fixed in this PR (Phase 1 — preamble injection).**
+
+### G4 — AgentFactory.md itself had no compiled sections
+Rules, commands, and skills were compiled into per-adapter briefs but never back
+into `AgentFactory.md`. The "master doc" was therefore less complete than the briefs
+it fed. **Fixed in this PR (Phase 2 — `_compile_agentfactory_md`).**
+
+### G5 — Harness Identity Block omitted AgentFactory.md from shared-context list
+The navigation section in every brief listed `skills/`, `rules/`, `agent-manifest.json`
+and `memory/milestones.md` — but not `AgentFactory.md`, the most important file to read
+after a CLI swap. **Fixed in this PR (`_fmt_harness_identity`).**
+
+### G6 — No per-adapter context budget (open until this PR)
+`_FORMAT_REGISTRY` had `skill_char_limit` per adapter, but no concept of a budget for
+project-context injection. Without it, all adapters would get the same preamble
+regardless of their effective context windows. **Fixed: `context_char_limit` added.**
+
+---
+
+## 5. Technical Reference
+
+### 5.1 Per-adapter context limits
+
+| Adapter | `context_char_limit` | Reason |
+|---------|---------------------|--------|
+| `claude` | 4 000 chars | Large context window; full preamble fits |
+| `codex` | 2 000 chars | Tighter instruction-following window; prioritise reliability |
+| `gemini` | 4 000 chars | Large context window; full preamble fits |
+
+### 5.2 Preamble extraction (`_collect_project_context`)
+
+```python
+# src/agent_gen/librarian.py
+
+def _collect_project_context(project_root: str) -> str:
+    af_path = Path(project_root) / HARNESS_ROOT / CONTEXT_FILE
+    content = af_path.read_text(encoding="utf-8")
+    marker = content.find("<!-- @")               # stop before first registry block
+    preamble = content[:marker].strip()
+    lines = preamble.splitlines()
+    if lines and lines[0].startswith("# "):       # strip H1 title (duplicates header)
+        lines = lines[1:]
+    return "\n".join(lines).strip()
+```
+
+### 5.3 Budget fitting (`_fit_context_to_budget`)
+
+Truncation happens at the last `\n\n` paragraph break before the limit. If no break
+is found in the first half of the window, the hard limit is used. The truncation is
+always annotated with an HTML comment so the AI agent can see exactly what was cut:
+
+```
+<!-- ⚠ context truncated: 3276 → 2000 chars for 95% budget. -->
+```
+
+When `AGENTFACTORY_LICENSE_KEY` is set, the comment also includes a completeness-check
+hint (advisory only, non-blocking). Full semantic oracle support tracked in #126.
+
+### 5.4 AgentFactory.md compilation (`_compile_agentfactory_md`)
+
+Called at the end of every `_compile_adapter_briefs()` run. Uses Claude's formatters
+(`_fmt_commands_list`, `_fmt_rules_list`) to produce the most readable universal
+markdown. Marker blocks are appended if absent, replaced in-place if already present.
+
+```
+<!-- @commands-start -->
+## Commands
+- `/completeness-check` — ...
+- `/git-workflow` — ...
+<!-- @commands-end -->
+
+<!-- @rules-start -->
+## Behavior Rules
+- **Quiet Mode:** ...
+- **Branches:** ...
+<!-- @rules-end -->
+```
+
+---
+
+## 6. CLI Switch Walkthrough
+
+Full step-by-step for a developer switching from Claude to Codex:
+
+```
+1.  Open project in Codex CLI.
+    Codex reads AGENTS.md → compiled codex/brief.md.
+
+2.  Brief now contains:
+    ## Harness
+      .ai/AgentFactory.md  ← project overview + master compiled brief  ← NEW
+      .ai/skills/  .ai/rules/  .ai/agent-manifest.json  .ai/memory/milestones.md
+      claude  CLAUDE.md  → .ai/adapters/claude/brief.md
+      codex   AGENTS.md  → .ai/adapters/codex/brief.md   ← YOU ARE HERE
+      gemini  GEMINI.md  → .ai/adapters/gemini/brief.md
+
+    ## Project Context                                                   ← NEW
+      [project architecture, dev commands, overview — up to 2000 chars]
+      <!-- ⚠ context truncated: 3276 → 2000 chars --> (if preamble > 2000)
+
+    ## Available Skills  ...
+    ## Registered Agents ...
+    ## Behavior Rules    ...
+
+3.  If codex adapter was not yet activated:
+    agentfactory-gen adapter add codex
+
+4.  If briefs are stale after pulling new code:
+    agentfactory-gen brief
+    → recompiles all active adapter briefs with current preamble
+```
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `## Project Context` missing from brief | Brief compiled before #125 | `agentfactory-gen brief` |
+| `context truncated` warning in codex brief | Preamble > 2000 chars (normal) | Shorten `AgentFactory.md` preamble, or accept truncation |
+| AgentFactory.md missing `@commands-start` | Brief never compiled after #125 | `agentfactory-gen brief` |
+| `## Project Context` shows registry blocks | `AgentFactory.md` has preamble after the `<!-- @` marker | Move human text above the first `<!-- @` marker |
+
+---
+
+## 8. Open Ends
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #126 | feat: extend completeness oracle to project-context preamble truncation | pending |
+
+When `AGENTFACTORY_LICENSE_KEY` is set and the preamble is truncated, the system
+currently adds a hint comment but does not run the oracle. #126 tracks extending the
+two-phase semantic completeness check to measure information loss during truncation
+and surface a completeness delta (e.g. `⚠ preamble completeness: 74%`).

--- a/docs/FEATURE-HARNESS-IDENTITY.md
+++ b/docs/FEATURE-HARNESS-IDENTITY.md
@@ -1,5 +1,5 @@
 # Harness Identity Block
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 
 Issue: #115 · Cross-adapter navigation header compiled into every brief
 
@@ -51,7 +51,9 @@ by removing a section key. It answers three questions immediately:
   _render_brief(adapter_name, config, data):
       sections = []
       sections.append(header)                      ← @compiled-by metadata
-      sections.append(_fmt_harness_identity(...))  ← harness block  ← NEW
+      sections.append(_fmt_harness_identity(...))  ← harness block (unconditional)
+      if data["project_context"]:                  ← NEW (#125)
+          sections.append("## Project Context\n\n" + fitted_preamble)
       for section_key in config["section_order"]:  ← skills/commands/rules
           ...
       return "\n\n".join(sections)
@@ -68,16 +70,20 @@ by removing a section key. It answers three questions immediately:
        └─ for each activated adapter:
                _render_brief(adapter_name, config, data)
                     │
-                    ├─ header block  (<!-- @compiled-by ... -->)
-                    ├─ ## Harness   ← _fmt_harness_identity()
+                    ├─ header block   (<!-- @compiled-by ... -->)
+                    ├─ ## Harness    ← _fmt_harness_identity()
+                    ├─ ## Project Context  ← NEW (#125, budget-fitted preamble)
                     ├─ ## Available Skills
-                    ├─ ## Commands  (claude only)
+                    ├─ ## Commands   (claude only)
                     ├─ ## Registered Agents
                     └─ ## Behavior Rules
                     │
                     ▼
               .ai/adapters/<name>/brief.md  (written to disk)
               CLAUDE.md / AGENTS.md / GEMINI.md  (root symlinks)
+
+       Also: _compile_agentfactory_md()  ← NEW (#125)
+              → upserts @commands + @rules into .ai/AgentFactory.md
 ```
 
 ---
@@ -99,6 +105,7 @@ by removing a section key. It answers three questions immediately:
 
   Shared context (read these to understand the project):
 
+    .ai/AgentFactory.md         ← project overview + master compiled brief
     .ai/skills/               ← skill specs (symlinked per adapter)
     .ai/rules/                ← behavior rules compiled into this brief
     .ai/agent-manifest.json   ← global agent registry

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,5 +1,5 @@
 # AgentFactory — Workflow Diagrams
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 
 Architecture, lifecycle, and pipeline diagrams for AgentFactory.
 See [README](../README.md) for installation and quick start.
@@ -12,22 +12,21 @@ See [README](../README.md) for installation and quick start.
 graph TD
     subgraph root["Project Root"]
         CM[CLAUDE.md]
-        AM[AGENTS.md]
+        AM["AGENTS.md / CODEX.md"]
         GM[GEMINI.md]
-        CO[CODEX.md]
         CL[.claude]
         GE[.gemini]
         CD[.codex]
     end
 
     subgraph harness[".ai/ — Unified Harness"]
-        AF["AgentFactory.md (single source of truth)"]
+        AF["AgentFactory.md (master compiled brief)"]
         MF["agent-manifest.json (global registry)"]
 
         subgraph adapters["adapters/"]
-            ACA["claude/ — settings.json"]
-            AGE["gemini/ — config.json"]
-            ACO["codex/ — config.toml"]
+            ACA_B["claude/brief.md (compiled)"]
+            AGE_B["gemini/brief.md (compiled)"]
+            ACO_B["codex/brief.md (compiled)"]
         end
 
         subgraph shared["shared/"]
@@ -39,23 +38,63 @@ graph TD
         end
     end
 
-    CM -->|symlink| AF
-    AM -->|symlink| AF
-    GM -->|symlink| AF
-    CO -->|symlink| AF
-    CL -->|symlink| ACA
-    GE -->|symlink| AGE
-    CD -->|symlink| ACO
+    CM -->|symlink| ACA_B
+    AM -->|symlink| ACO_B
+    GM -->|symlink| AGE_B
+    CL -->|symlink to adapter dir| adapters
+    GE -->|symlink to adapter dir| adapters
+    CD -->|symlink to adapter dir| adapters
 
-    ACA -->|commands| CMD
-    ACA -->|skills| SK
-    AGE -->|tools| SK
-    ACO -->|prompts| CMD
+    RU -->|compiled into| ACA_B
+    RU -->|compiled into| ACO_B
+    RU -->|compiled into| AGE_B
+    CMD -->|compiled into| ACA_B
+    SK -->|compiled into| ACA_B
+    SK -->|compiled into| ACO_B
+    SK -->|compiled into| AGE_B
+    AF -->|preamble injected into| ACA_B
+    AF -->|preamble injected into| ACO_B
+    AF -->|preamble injected into| AGE_B
+```
+
+> **Note:** Root files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) are symlinks to
+> per-adapter compiled briefs — **not** to `AgentFactory.md` directly. This is the
+> FormatSwitch model introduced in #96. `AgentFactory.md` is a full master compiled
+> brief that is also the preamble source for every adapter brief.
+
+---
+
+## 2. Brief Compilation Pipeline (`agentfactory-gen brief`)
+
+```mermaid
+flowchart TD
+    subgraph sources["Input Sources (.ai/)"]
+        SK[skills/]
+        AG[agents/]
+        CMD[commands/]
+        RU[rules/]
+        AF["AgentFactory.md\n(preamble extracted)"]
+    end
+
+    SK & AG & CMD & RU & AF --> COLLECT["_compile_adapter_briefs()\ncollect data dict"]
+
+    COLLECT --> RC["_render_brief() × adapter"]
+
+    RC --> CB["claude/brief.md\ncontext_char_limit: 4000"]
+    RC --> COB["codex/brief.md\ncontext_char_limit: 2000"]
+    RC --> GB["gemini/brief.md\ncontext_char_limit: 4000"]
+
+    CB --> |sections| CS["## Harness\n## Project Context\n## Skills\n## Commands\n## Agents\n## Rules"]
+    COB --> |sections| COS["## Harness\n## Project Context\n(truncated if > 2000)\n## Skills\n## Agents\n## Rules"]
+    GB --> |sections| GS["## Harness\n## Project Context\n## Skills\n## Agents\n## Rules"]
+
+    COLLECT --> AFCOMP["_compile_agentfactory_md()\nupsert @commands + @rules into AgentFactory.md"]
+    AFCOMP --> AF
 ```
 
 ---
 
-## 2. Agent Lifecycle
+## 3. Agent Lifecycle
 
 ```mermaid
 flowchart LR
@@ -92,7 +131,7 @@ flowchart LR
 
 ---
 
-## 3. Remote Import Pipeline (`--from-git`)
+## 4. Remote Import Pipeline (`--from-git`)
 
 ```mermaid
 flowchart TD
@@ -123,7 +162,7 @@ flowchart TD
 
 ---
 
-## 4. Librarian Intelligence Layer
+## 5. Librarian Intelligence Layer
 
 ```mermaid
 flowchart TD
@@ -149,7 +188,7 @@ flowchart TD
 
 ---
 
-## 5. Multi-CLI Harness — Adapter Wiring
+## 6. Multi-CLI Harness — Adapter Wiring
 
 ```mermaid
 graph LR
@@ -185,7 +224,7 @@ graph LR
 
 ---
 
-## 6. CI Pipeline (every push / PR)
+## 7. CI Pipeline (every push / PR)
 
 ```mermaid
 flowchart TD
@@ -211,7 +250,7 @@ flowchart TD
 
 ---
 
-## 7. CD Pipeline (on version tag)
+## 8. CD Pipeline (on version tag)
 
 ```mermaid
 flowchart TD
@@ -237,7 +276,7 @@ flowchart TD
 
 ---
 
-## 8. Traceability / Milestone Update Workflow
+## 9. Traceability / Milestone Update Workflow
 
 ```mermaid
 flowchart TD

--- a/src/agent_gen/librarian.py
+++ b/src/agent_gen/librarian.py
@@ -152,6 +152,8 @@ _FORMAT_REGISTRY: dict[str, dict] = {
         "skill_char_limit": 18_000,
         # Completeness score threshold (0–100) for --check-completeness.
         "completeness_threshold": 90,
+        # Max chars of AgentFactory.md preamble to inject into this brief.
+        "context_char_limit": 4_000,
     },
     "codex": {
         "output": "brief.md",
@@ -176,6 +178,7 @@ _FORMAT_REGISTRY: dict[str, dict] = {
         # Codex has a tighter context window — stricter per-skill budget.
         "skill_char_limit": 10_000,
         "completeness_threshold": 95,
+        "context_char_limit": 2_000,
     },
     "gemini": {
         "output": "brief.md",
@@ -198,6 +201,7 @@ _FORMAT_REGISTRY: dict[str, dict] = {
         "section_order": ["skills", "agents", "rules"],
         "skill_char_limit": 18_000,
         "completeness_threshold": 90,
+        "context_char_limit": 4_000,
     },
 }
 
@@ -298,6 +302,7 @@ def _fmt_harness_identity(adapter_name: str) -> str:
         "",
         "Shared context (read these to understand the project):",
         "",
+        f"  {HARNESS_ROOT}/{CONTEXT_FILE:<23} ← project overview + master compiled brief",
         f"  {HARNESS_ROOT}/skills/               ← skill specs (symlinked per adapter)",
         f"  {HARNESS_ROOT}/rules/                ← behavior rules compiled into this brief",
         f"  {HARNESS_ROOT}/agent-manifest.json   ← global agent registry",
@@ -318,6 +323,52 @@ def _fmt_harness_identity(adapter_name: str) -> str:
         "If switching CLI: run `agentfactory-gen brief` to recompile all active adapter briefs.",
     ]
     return "\n".join(lines)
+
+
+def _collect_project_context(project_root: str) -> str:
+    """Extract the human-written preamble from .ai/AgentFactory.md.
+
+    Returns everything before the first <!-- @ registry marker, with the H1
+    title line stripped (it duplicates the adapter brief header).
+    """
+    af_path = Path(project_root) / HARNESS_ROOT / CONTEXT_FILE
+    if not af_path.exists():
+        return ""
+    content = af_path.read_text(encoding="utf-8")
+    marker = content.find("<!-- @")
+    preamble = content[:marker].strip() if marker > 0 else content.strip()
+    lines = preamble.splitlines()
+    if lines and lines[0].startswith("# "):
+        lines = lines[1:]
+    return "\n".join(lines).strip()
+
+
+def _fit_context_to_budget(context: str, adapter_config: dict) -> str:
+    """Truncate preamble to adapter's context_char_limit.
+
+    Truncates at the last paragraph break before the limit. Appends an HTML
+    comment warning if truncated. Adds a completeness-check hint when
+    AGENTFACTORY_LICENSE_KEY is set (pro gate advisory, non-blocking).
+    """
+    limit = adapter_config.get("context_char_limit", 4_000)
+    if len(context) <= limit:
+        return context
+    window = context[:limit]
+    cut = window.rfind("\n\n")
+    if cut < limit // 2:
+        cut = limit
+    truncated = context[:cut].rstrip()
+    original_len = len(context)
+    has_key = bool(os.environ.get("AGENTFACTORY_LICENSE_KEY"))
+    completeness_hint = (
+        " Run: python3 .ai/scripts/skill-completeness-check.py --context to verify."
+        if has_key else ""
+    )
+    warning = (
+        f"\n\n<!-- ⚠ context truncated: {original_len} → {limit} chars "
+        f"for {adapter_config.get('completeness_threshold', 90)}% budget.{completeness_hint} -->"
+    )
+    return truncated + warning
 
 
 _FORMATTER_DISPATCH: dict = {
@@ -1266,6 +1317,10 @@ class Librarian:
         )
         sections.append(header)
         sections.append(_fmt_harness_identity(adapter_name))
+        ctx = data.get("project_context", "")
+        if ctx:
+            fitted = _fit_context_to_budget(ctx, config)
+            sections.append(f"## Project Context\n\n{fitted}")
         for section_key in config["section_order"]:
             formatter_name = config["sections"].get(section_key)
             if formatter_name is None:
@@ -1287,10 +1342,11 @@ class Librarian:
             return
 
         data = {
-            "skills":   cls._collect_skills_data(project_root),
-            "agents":   cls._collect_agents_data(project_root),
-            "commands": cls._collect_commands_data(project_root),
-            "rules":    cls._collect_rules_data(project_root),
+            "skills":          cls._collect_skills_data(project_root),
+            "agents":          cls._collect_agents_data(project_root),
+            "commands":        cls._collect_commands_data(project_root),
+            "rules":           cls._collect_rules_data(project_root),
+            "project_context": _collect_project_context(project_root),
         }
 
         for adapter_name, config in _FORMAT_REGISTRY.items():
@@ -1305,6 +1361,42 @@ class Librarian:
                 brief_path.write_text(new_content, encoding="utf-8")
             except Exception as e:
                 _click.echo(f"Warning: failed to compile brief for {adapter_name}: {e}", err=True)
+
+        cls._compile_agentfactory_md(project_root, data)
+
+    @classmethod
+    def _compile_agentfactory_md(cls, project_root: str, data: dict) -> None:
+        """Upsert <!-- @commands-start/end --> and <!-- @rules-start/end --> into AgentFactory.md.
+
+        Uses Claude's formatters (most readable universal markdown) so AgentFactory.md
+        becomes a full master brief — same richness as per-adapter compiled briefs.
+        Marker blocks are appended if absent, replaced if present.
+        """
+        af_path = Path(project_root) / HARNESS_ROOT / CONTEXT_FILE
+        if not af_path.exists():
+            return
+        content = af_path.read_text(encoding="utf-8")
+        claude_cfg = _FORMAT_REGISTRY["claude"]
+        commands_text = _fmt_commands_list(data.get("commands", []), claude_cfg) or ""
+        rules_text = _fmt_rules_list(data.get("rules", []), claude_cfg) or ""
+
+        commands_block = f"<!-- @commands-start -->\n{commands_text}\n<!-- @commands-end -->"
+        rules_block = f"<!-- @rules-start -->\n{rules_text}\n<!-- @rules-end -->"
+
+        commands_pat = re.compile(r"<!-- @commands-start -->.*?<!-- @commands-end -->", re.DOTALL)
+        rules_pat = re.compile(r"<!-- @rules-start -->.*?<!-- @rules-end -->", re.DOTALL)
+
+        if "<!-- @commands-start -->" in content:
+            content = commands_pat.sub(commands_block, content)
+        else:
+            content = content.rstrip() + f"\n\n{commands_block}\n"
+
+        if "<!-- @rules-start -->" in content:
+            content = rules_pat.sub(rules_block, content)
+        else:
+            content = content.rstrip() + f"\n\n{rules_block}\n"
+
+        af_path.write_text(content, encoding="utf-8")
 
     @classmethod
     def _migrate_root_symlinks(cls, project_root: str) -> None:

--- a/src/tests/test_api_auth.py
+++ b/src/tests/test_api_auth.py
@@ -2,6 +2,9 @@
 import os
 import tempfile
 import unittest
+import importlib
+import uuid
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 # Set required env vars before importing the app
@@ -105,7 +108,6 @@ class TestAuthMe(unittest.TestCase):
         self.assertEqual(resp.status_code, 401)
 
     def test_me_with_valid_session_returns_user(self):
-        import tempfile, importlib
         with tempfile.TemporaryDirectory() as tmp:
             os.environ["DATABASE_URL"] = f"sqlite:///{tmp}/test.db"
             import agent_gen.api.db as db_module
@@ -176,6 +178,156 @@ class TestGithubLoginUnconfigured(unittest.TestCase):
         finally:
             if saved:
                 os.environ["GITHUB_CLIENT_ID"] = saved
+
+
+class TestGithubOAuthCallback(unittest.TestCase):
+    """Tests for /auth/github (login redirect) and /auth/github/callback."""
+
+    def _setup_db(self, tmp: str):
+        os.environ["DATABASE_URL"] = f"sqlite:///{tmp}/test.db"
+        import agent_gen.api.db as db_module
+        importlib.reload(db_module)
+        db_module.init_db()
+        import agent_gen.api.deps as deps_module
+        importlib.reload(deps_module)
+        return db_module
+
+    def _get_client_and_state(self, auth_env: dict | None = None):
+        """Return (TestClient, auth_module, state_token) with a real pending state."""
+        if auth_env:
+            for k, v in auth_env.items():
+                os.environ[k] = v
+        os.environ.setdefault("GITHUB_CLIENT_ID", "test-client-id")
+        import agent_gen.api.routers.auth as auth_module
+        importlib.reload(auth_module)
+        import agent_gen.api.main as main_module
+        importlib.reload(main_module)
+        from fastapi.testclient import TestClient
+        client = TestClient(main_module.app, raise_server_exceptions=True)
+        # Trigger /auth/github to plant a real state token
+        redir = client.get("/auth/github", follow_redirects=False)
+        location = redir.headers.get("location", "")
+        state = ""
+        for part in location.split("&"):
+            if part.startswith("state=") or "?state=" in part:
+                state = part.split("state=", 1)[-1]
+        return client, auth_module, state
+
+    def test_github_login_redirects_to_github_oauth(self):
+        client, _, _ = self._get_client_and_state()
+        redir = client.get("/auth/github", follow_redirects=False)
+        self.assertIn(redir.status_code, [302, 307])
+        self.assertIn("github.com/login/oauth/authorize", redir.headers["location"])
+        self.assertIn("test-client-id", redir.headers["location"])
+
+    def test_github_callback_invalid_state_returns_400(self):
+        client, _, _ = self._get_client_and_state()
+        resp = client.get("/auth/github/callback?code=abc&state=completely-invalid-state")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_github_callback_no_access_token_returns_502(self):
+        client, auth_module, state = self._get_client_and_state()
+        auth_module._pending_states[state] = True
+        with patch("agent_gen.api.routers.auth.httpx.post") as mock_post:
+            mock_post.return_value = MagicMock(json=lambda: {})
+            resp = client.get(f"/auth/github/callback?code=testcode&state={state}")
+            self.assertEqual(resp.status_code, 502)
+
+    def test_github_callback_user_fetch_failure_returns_502(self):
+        client, auth_module, state = self._get_client_and_state()
+        auth_module._pending_states[state] = True
+        with patch("agent_gen.api.routers.auth.httpx.post") as mock_post, \
+             patch("agent_gen.api.routers.auth.httpx.get") as mock_get:
+            mock_post.return_value = MagicMock(json=lambda: {"access_token": "tok"})
+            mock_get.return_value = MagicMock(status_code=500)
+            resp = client.get(f"/auth/github/callback?code=testcode&state={state}")
+            self.assertEqual(resp.status_code, 502)
+
+    def test_github_callback_creates_new_user_and_sets_cookie(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = self._setup_db(tmp)
+            client, auth_module, state = self._get_client_and_state()
+            auth_module._pending_states[state] = True
+            with patch("agent_gen.api.routers.auth.httpx.post") as mock_post, \
+                 patch("agent_gen.api.routers.auth.httpx.get") as mock_get:
+                mock_post.return_value = MagicMock(json=lambda: {"access_token": "tok"})
+                user_data = {
+                    "id": 11111, "login": "newuser",
+                    "email": "new@example.com", "avatar_url": "",
+                }
+                mock_get.return_value = MagicMock(
+                    status_code=200, json=lambda: user_data
+                )
+                resp = client.get(
+                    f"/auth/github/callback?code=testcode&state={state}",
+                    follow_redirects=False,
+                )
+            self.assertIn(resp.status_code, [302, 307])
+            self.assertIn("session", resp.cookies)
+            with db.get_conn() as conn:
+                row = conn.execute(
+                    "SELECT github_handle, plan FROM users WHERE github_id = ?", (11111,)
+                ).fetchone()
+            self.assertIsNotNone(row)
+            self.assertEqual(row["github_handle"], "newuser")
+            self.assertEqual(row["plan"], "free")
+
+    def test_github_callback_updates_existing_user_preserves_plan(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = self._setup_db(tmp)
+            now = datetime.now(timezone.utc).isoformat()
+            existing_id = str(uuid.uuid4())
+            with db.get_conn() as conn:
+                conn.execute(
+                    "INSERT INTO users (id, github_id, github_handle, email, avatar_url, plan, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (existing_id, 22222, "oldhandle", "old@x.com", "", "pro", now, now),
+                )
+            client, auth_module, state = self._get_client_and_state()
+            auth_module._pending_states[state] = True
+            with patch("agent_gen.api.routers.auth.httpx.post") as mock_post, \
+                 patch("agent_gen.api.routers.auth.httpx.get") as mock_get:
+                mock_post.return_value = MagicMock(json=lambda: {"access_token": "tok"})
+                updated = {"id": 22222, "login": "newhandle", "email": "new@x.com", "avatar_url": ""}
+                mock_get.return_value = MagicMock(status_code=200, json=lambda: updated)
+                client.get(
+                    f"/auth/github/callback?code=testcode&state={state}",
+                    follow_redirects=False,
+                )
+            with db.get_conn() as conn:
+                row = conn.execute(
+                    "SELECT id, github_handle, plan FROM users WHERE github_id = ?", (22222,)
+                ).fetchone()
+            self.assertEqual(row["id"], existing_id)
+            self.assertEqual(row["github_handle"], "newhandle")
+            self.assertEqual(row["plan"], "pro")  # plan not overwritten on update
+
+    def test_github_callback_email_fallback_from_emails_endpoint(self):
+        """When user has no public email, callback fetches from /user/emails."""
+        with tempfile.TemporaryDirectory() as tmp:
+            db = self._setup_db(tmp)
+            client, auth_module, state = self._get_client_and_state()
+            auth_module._pending_states[state] = True
+            with patch("agent_gen.api.routers.auth.httpx.post") as mock_post, \
+                 patch("agent_gen.api.routers.auth.httpx.get") as mock_get:
+                mock_post.return_value = MagicMock(json=lambda: {"access_token": "tok"})
+                # First call: user has no email
+                user_no_email = {"id": 33333, "login": "noemailer", "email": None, "avatar_url": ""}
+                # Second call: /user/emails returns primary
+                emails_data = [{"email": "private@x.com", "primary": True, "verified": True}]
+                mock_get.side_effect = [
+                    MagicMock(status_code=200, json=lambda: user_no_email),
+                    MagicMock(status_code=200, json=lambda: emails_data),
+                ]
+                client.get(
+                    f"/auth/github/callback?code=testcode&state={state}",
+                    follow_redirects=False,
+                )
+            with db.get_conn() as conn:
+                row = conn.execute(
+                    "SELECT email FROM users WHERE github_id = ?", (33333,)
+                ).fetchone()
+            self.assertEqual(row["email"], "private@x.com")
 
 
 if __name__ == "__main__":

--- a/src/tests/test_librarian_lifecycle.py
+++ b/src/tests/test_librarian_lifecycle.py
@@ -448,5 +448,113 @@ class TestFormatSwitchLibrarian(unittest.TestCase):
             self.assertIn("updated-skill", content)
 
 
+class TestProjectContextInjection(unittest.TestCase):
+    """Tests for preamble extraction + injection into compiled adapter briefs."""
+
+    def _make_harness(self, root: Path, af_content: str | None = None) -> None:
+        ai = root / HARNESS_ROOT
+        for d in ["adapters/claude", "adapters/codex", "adapters/gemini",
+                  "skills", "commands", "rules", "agents", "memory"]:
+            (ai / d).mkdir(parents=True, exist_ok=True)
+        (ai / "agent-manifest.json").write_text(
+            '{"factory":"AgentFactory","agents":{}}', encoding="utf-8"
+        )
+        if af_content is not None:
+            (ai / CONTEXT_FILE).write_text(af_content, encoding="utf-8")
+
+    def test_brief_includes_project_context_from_agentfactory_md(self):
+        """Compiled claude brief contains ## Project Context with the preamble text."""
+        preamble = "This project does something cool.\n\nMore details here."
+        af_content = f"# My Project\n\n{preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "claude" / "brief.md").read_text(encoding="utf-8")
+            self.assertIn("## Project Context", brief)
+            self.assertIn("This project does something cool.", brief)
+
+    def test_brief_strips_h1_and_registries_from_project_context(self):
+        """H1 title and <!-- @ blocks do not appear inside ## Project Context."""
+        af_content = (
+            "# AgentFactory\n\n"
+            "Project preamble text.\n\n"
+            "<!-- @agent-registry:start -->\nsome agent\n<!-- @agent-registry:end -->\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "claude" / "brief.md").read_text(encoding="utf-8")
+            self.assertIn("Project preamble text.", brief)
+            self.assertNotIn("<!-- @agent-registry", brief)
+            # H1 title should not appear inside the Project Context section
+            ctx_start = brief.find("## Project Context")
+            self.assertNotIn("# AgentFactory", brief[ctx_start:ctx_start + 200])
+
+    def test_brief_project_context_absent_when_agentfactory_md_missing(self):
+        """No AgentFactory.md → brief compiles without error, no ## Project Context."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content=None)
+            Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "claude" / "brief.md").read_text(encoding="utf-8")
+            self.assertNotIn("## Project Context", brief)
+
+    def test_brief_truncates_preamble_for_tight_budget(self):
+        """Codex brief truncates preamble > context_char_limit with warning comment."""
+        long_preamble = ("A" * 500 + "\n\n") * 10  # ~5100 chars
+        af_content = f"# Title\n\n{long_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "codex" / "brief.md").read_text(encoding="utf-8")
+            # codex context_char_limit = 2000; preamble is ~5000 chars
+            ctx_start = brief.find("## Project Context")
+            self.assertGreater(ctx_start, -1)
+            ctx_section = brief[ctx_start:]
+            self.assertIn("<!-- ⚠ context truncated:", ctx_section)
+
+    def test_brief_no_truncation_when_within_budget(self):
+        """Claude brief: preamble <= 4000 chars → no truncation warning."""
+        short_preamble = "Short project description.\n\nSecond paragraph."
+        af_content = f"# Title\n\n{short_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "claude" / "brief.md").read_text(encoding="utf-8")
+            self.assertNotIn("context truncated", brief)
+            self.assertIn("Short project description.", brief)
+
+    def test_compile_agentfactory_md_adds_rules_and_commands(self):
+        """After _compile_adapter_briefs, AgentFactory.md contains rules + commands blocks."""
+        af_content = "# My Project\n\nPreamble.\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            # Add a rule and command so sections are non-empty
+            (root / HARNESS_ROOT / "rules" / "no-secrets.md").write_text(
+                "- Never commit secrets.", encoding="utf-8"
+            )
+            (root / HARNESS_ROOT / "commands" / "git-workflow.md").write_text(
+                "<!-- version: 1.0.0 -->\nGit workflow command.", encoding="utf-8"
+            )
+            Librarian._compile_adapter_briefs(str(root))
+            af = (root / HARNESS_ROOT / CONTEXT_FILE).read_text(encoding="utf-8")
+            self.assertIn("<!-- @commands-start -->", af)
+            self.assertIn("<!-- @commands-end -->", af)
+            self.assertIn("<!-- @rules-start -->", af)
+            self.assertIn("<!-- @rules-end -->", af)
+
+    def test_harness_identity_references_agentfactory_md(self):
+        """_fmt_harness_identity output lists AgentFactory.md in shared context."""
+        from agent_gen.librarian import _fmt_harness_identity
+        identity = _fmt_harness_identity("claude")
+        self.assertIn("AgentFactory.md", identity)
+        self.assertIn("project overview", identity)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

### Core feature — AgentFactory.md as master brief + preamble injection (#125)
- Every adapter brief (CLAUDE.md, AGENTS.md, GEMINI.md) now has a `## Project Context` section injected with the preamble from `.ai/AgentFactory.md`, budget-fitted per adapter (claude/gemini: 4 000 chars, codex: 2 000 chars). Truncation appends an HTML comment warning; if `AGENTFACTORY_LICENSE_KEY` is set, a completeness-check hint is included.
- `.ai/AgentFactory.md` is compiled as a **full master brief** — `agentfactory-gen brief` upserts `<!-- @commands-start/end -->` and `<!-- @rules-start/end -->` sections so it has the same richness as the adapter-specific briefs.
- `_fmt_harness_identity()` navigation block now lists `.ai/AgentFactory.md` explicitly in the shared-context section.

### Fixes included
- `agentfactory-gen init` now creates root symlinks for all adapters, not only the primary (#120)
- `update_harness_files()` now injects skills section into files lacking the marker (#121)
- `docs/WORKFLOWS.md` diagram 1 was architecturally stale since FormatSwitch (#96) — fixed

### Documentation (docs: commit c4cd5a2)
- **New:** `docs/FEATURE-AGENTFACTORY-MD-BRIEF.md` — complete workflow diagram (terminal box-draw), 6-point gap analysis, technical reference, CLI switch walkthrough
- **Updated:** `docs/WORKFLOWS.md` — fixed stale diagram 1; added diagram 2 (compilation pipeline with preamble injection); renumbered sections
- **Updated:** `docs/FEATURE-HARNESS-IDENTITY.md` — pipeline diagram, shared-context list
- **Updated:** `README.md` — new "Project Context Injection" feature section, fixed AgentFactory.md description, v2.8.0
- **Updated:** `CHANGELOG.md` — v2.8.0, v2.7.0, v2.6.0 entries

## Test plan

- [x] 7 new unit tests in `test_librarian_lifecycle.py`: context injection, H1/registry stripping, missing-AF.md graceful compile, codex truncation, claude no-truncation, AgentFactory.md rules+commands upsert, harness identity reference
- [x] `python3 -m pytest src/tests/ -q` — **203 passed**
- [x] `agentfactory-gen brief` smoke test — all adapters show `## Project Context`; codex brief has truncation warning; `AgentFactory.md` contains `<!-- @commands-start -->` and `<!-- @rules-start -->` with real content

## New issue opened
- [#126](https://github.com/matheusmlopess/AgentFactory/issues/126) — feat: extend completeness oracle to project-context preamble truncation

## Release target
- `v2.8.0` — this PR + #120/#121 (v2.6.0) + #114 (v2.7.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)