### PR TITLE
feat: extend completeness oracle to preamble truncation (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AgentFactory
-<!-- version: 2.8.0 -->
+<!-- version: 2.9.0 -->
 
 A Python CLI (`agentfactory-gen`) for building, packaging, and deploying AI agents
 as portable, framework-agnostic units. The web platform lives at
@@ -182,6 +182,18 @@ character budget:
 | Gemini | 4 000 chars | Full preamble |
 | Codex | 2 000 chars | Truncated at paragraph boundary + `<!-- ⚠ context truncated -->` comment |
 
+When truncation occurs and `AGENTFACTORY_LICENSE_KEY` is set, the completeness oracle
+runs automatically during `agentfactory-gen brief` and prints the information-retention
+score to stderr — no manual invocation needed:
+
+```
+⚠ preamble completeness: 74%
+```
+
+The check is **advisory only**: it never blocks compilation or changes brief content.
+It tells you how much of the original preamble's meaning survived the truncation so
+you can decide whether to shorten the preamble or raise the adapter's `context_char_limit`.
+
 `AgentFactory.md` is also compiled as a **full master brief**: `agentfactory-gen brief`
 upserts `<!-- @commands-start/end -->` and `<!-- @rules-start/end -->` sections so it
 has the same richness as any adapter brief. Reading it directly gives a complete
@@ -192,6 +204,8 @@ picture of the project.
 agentfactory-gen brief
 # → All adapter briefs updated with new preamble
 # → AgentFactory.md updated with latest rules + commands
+# → If truncation occurred and AGENTFACTORY_LICENSE_KEY is set:
+#   ⚠ preamble completeness: X%  (printed to stderr, advisory)
 ```
 
 Full reference: [`docs/FEATURE-AGENTFACTORY-MD-BRIEF.md`](docs/FEATURE-AGENTFACTORY-MD-BRIEF.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ api = [
 testpaths = ["src/tests"]
 markers = [
     "integration: end-to-end stress tests that exercise the full CLI lifecycle (slow, deselect with -m 'not integration')",
+    "live: tests that invoke real CLI agents (claude/codex/gemini); skipped when CLIs not installed",
 ]
 
 [tool.coverage.run]

--- a/src/agent_gen/librarian.py
+++ b/src/agent_gen/librarian.py
@@ -3,6 +3,7 @@
 import json
 import os
 import re
+import sys
 import zipfile
 import shutil
 import subprocess
@@ -343,12 +344,44 @@ def _collect_project_context(project_root: str) -> str:
     return "\n".join(lines).strip()
 
 
-def _fit_context_to_budget(context: str, adapter_config: dict) -> str:
+def _run_preamble_oracle(original: str, truncated: str, project_root: str) -> int | None:
+    """Run phases 1+2 of the completeness oracle on truncated preamble vs original.
+
+    Returns score (0-100) or None if oracle is unavailable or errors.
+    Prints result to stderr. Never raises.
+    """
+    try:
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            return None
+        script_path = Path(project_root) / HARNESS_ROOT / "scripts" / "skill-completeness-check.py"
+        if not script_path.exists():
+            return None
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_oracle", script_path)
+        oracle = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(oracle)  # type: ignore[union-attr]
+        import anthropic as _anthropic
+        client = _anthropic.Anthropic(api_key=api_key)
+        model = oracle._DEFAULT_MODEL
+        atoms = oracle.phase1_extract_atoms(client, original, model)
+        results = oracle.phase2_verify_atoms(client, atoms, truncated, model)
+        score, _ = oracle.compute_score(atoms, results)
+        print(f"⚠ preamble completeness: {score}%", file=sys.stderr)
+        return score
+    except Exception:
+        return None
+
+
+def _fit_context_to_budget(
+    context: str, adapter_config: dict, project_root: str | None = None
+) -> str:
     """Truncate preamble to adapter's context_char_limit.
 
     Truncates at the last paragraph break before the limit. Appends an HTML
-    comment warning if truncated. Adds a completeness-check hint when
-    AGENTFACTORY_LICENSE_KEY is set (pro gate advisory, non-blocking).
+    comment warning if truncated. When AGENTFACTORY_LICENSE_KEY is set and
+    project_root is provided, runs the completeness oracle and prints the
+    delta to stderr (pro gate advisory, non-blocking).
     """
     limit = adapter_config.get("context_char_limit", 4_000)
     if len(context) <= limit:
@@ -360,6 +393,11 @@ def _fit_context_to_budget(context: str, adapter_config: dict) -> str:
     truncated = context[:cut].rstrip()
     original_len = len(context)
     has_key = bool(os.environ.get("AGENTFACTORY_LICENSE_KEY"))
+    if has_key and project_root:
+        try:
+            _run_preamble_oracle(context, truncated, project_root)
+        except Exception:
+            pass
     completeness_hint = (
         " Run: python3 .ai/scripts/skill-completeness-check.py --context to verify."
         if has_key else ""
@@ -1306,7 +1344,9 @@ class Librarian:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _render_brief(cls, adapter_name: str, config: dict, data: dict) -> str:
+    def _render_brief(
+        cls, adapter_name: str, config: dict, data: dict, project_root: str | None = None
+    ) -> str:
         sections = []
         header = (
             f"{config['header']}\n"
@@ -1319,7 +1359,7 @@ class Librarian:
         sections.append(_fmt_harness_identity(adapter_name))
         ctx = data.get("project_context", "")
         if ctx:
-            fitted = _fit_context_to_budget(ctx, config)
+            fitted = _fit_context_to_budget(ctx, config, project_root=project_root)
             sections.append(f"## Project Context\n\n{fitted}")
         for section_key in config["section_order"]:
             formatter_name = config["sections"].get(section_key)
@@ -1355,7 +1395,7 @@ class Librarian:
                 continue
             brief_path = adapter_dir / config["output"]
             try:
-                new_content = cls._render_brief(adapter_name, config, data)
+                new_content = cls._render_brief(adapter_name, config, data, project_root=str(project_root))
                 if brief_path.exists() and brief_path.read_text(encoding="utf-8") == new_content:
                     continue
                 brief_path.write_text(new_content, encoding="utf-8")

--- a/src/tests/scenarios/live_agent_check.py
+++ b/src/tests/scenarios/live_agent_check.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+live_agent_check.py — Tier 2 live CLI agent harness verification.
+
+Initializes a fresh AgentFactory project, adds a recognizable skill,
+then invokes the target CLI agent and asserts it acknowledges the harness.
+
+Usage:
+    python3 src/tests/scenarios/live_agent_check.py claude
+    python3 src/tests/scenarios/live_agent_check.py codex
+    python3 src/tests/scenarios/live_agent_check.py gemini
+
+Exit codes:
+    0  — PASS or SKIP (CLI not installed)
+    1  — FAIL (agent response missing expected keywords)
+    2  — ERROR (invocation failed)
+"""
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_PROBE_PROMPT = (
+    "What harness root does this project use? "
+    "What adapter are you running in? "
+    "Name one available skill."
+)
+
+# CLI invocation per adapter. Flags are best-effort — verify for your version.
+_CLI_INVOCATION = {
+    "claude": ["claude", "--print", _PROBE_PROMPT],
+    "codex":  ["codex",  "exec", "--skip-git-repo-check", _PROBE_PROMPT],
+    "gemini": ["gemini", "--prompt", _PROBE_PROMPT],
+}
+
+# Keywords a well-briefed agent should mention (lowercase, any substring match).
+_EXPECTED_KEYWORDS = {
+    "claude": [".ai", "harness"],
+    "codex":  [".ai", "harness"],
+    "gemini": [".ai", "harness"],
+}
+
+_SUPPORTED = list(_CLI_INVOCATION.keys())
+
+
+def _init_project(proj: Path, adapter: str) -> None:
+    from click.testing import CliRunner
+    from agent_gen.cli import cli
+    from agent_gen.librarian import HARNESS_ROOT
+
+    runner = CliRunner()
+    r = runner.invoke(cli, ["init", "--primary", adapter, "--project-root", str(proj)])
+    if r.exit_code != 0:
+        raise RuntimeError(f"agentfactory-gen init failed:\n{r.output}")
+
+    # Add a recognisable skill
+    skill_dir = proj / HARNESS_ROOT / "skills" / "deploy-pipeline"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "skill-manifest.json").write_text(
+        json.dumps({
+            "name": "deploy-pipeline",
+            "description": "Automates the CI/CD deploy pipeline end-to-end",
+            "triggers": "when deploying to production",
+            "input": "",
+        }),
+        encoding="utf-8",
+    )
+
+    r2 = runner.invoke(cli, ["brief", "--project-root", str(proj)])
+    if r2.exit_code != 0:
+        raise RuntimeError(f"agentfactory-gen brief failed:\n{r2.output}")
+
+
+def check(adapter: str) -> int:
+    if adapter not in _SUPPORTED:
+        print(f"ERROR: unknown adapter '{adapter}'. Choose from: {_SUPPORTED}")
+        return 2
+
+    if not shutil.which(adapter):
+        print(f"SKIP: '{adapter}' CLI not installed on PATH")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix=f"af_live_{adapter}_") as tmp:
+        proj = Path(tmp) / "proj"
+        proj.mkdir()
+
+        print(f"[setup] Initializing project at {proj} with primary={adapter} ...")
+        try:
+            _init_project(proj, adapter)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}")
+            return 2
+
+        print(f"[invoke] Running: {' '.join(_CLI_INVOCATION[adapter])}")
+        try:
+            proc = subprocess.run(
+                _CLI_INVOCATION[adapter],
+                cwd=str(proj),
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            print(f"ERROR: {adapter} CLI timed out after 120s")
+            return 2
+        except FileNotFoundError:
+            print(f"ERROR: {adapter} binary not found (PATH issue?)")
+            return 2
+
+        response = (proc.stdout + proc.stderr).lower()
+        print(f"[response] exit={proc.returncode}, len={len(response)}")
+        print(f"[response excerpt]\n{response[:600]}\n{'─'*60}")
+
+        missing = [kw for kw in _EXPECTED_KEYWORDS[adapter] if kw.lower() not in response]
+        if missing:
+            print(f"FAIL: response missing keywords: {missing}")
+            return 1
+
+        print(f"PASS: {adapter} acknowledged the AgentFactory harness")
+        return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__)
+        sys.exit(0)
+    sys.exit(check(sys.argv[1]))

--- a/src/tests/test_cli_swap_scenarios.py
+++ b/src/tests/test_cli_swap_scenarios.py
@@ -16,10 +16,8 @@ Run Tier 2 (live CLIs required):
     pytest src/tests/test_cli_swap_scenarios.py -m live -v
 """
 import json
-import os
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/src/tests/test_cli_swap_scenarios.py
+++ b/src/tests/test_cli_swap_scenarios.py
@@ -1,0 +1,446 @@
+"""
+CLI swap scenario tests — all adapter permutations.
+
+Tier 1 (CI-safe): Uses CliRunner + isolated_filesystem to simulate every
+init → adapter-add → brief recompile permutation across claude, codex, gemini.
+Verifies YOU ARE HERE marker, Project Context, per-adapter format differences,
+cross-adapter table completeness, and root file wiring.
+
+Tier 2 (live): Marked @pytest.mark.live. Invokes actual CLIs (claude / codex /
+gemini) via subprocess. Skips automatically when the CLI is not installed.
+
+Run Tier 1 only:
+    pytest src/tests/test_cli_swap_scenarios.py -m "not live" -v
+
+Run Tier 2 (live CLIs required):
+    pytest src/tests/test_cli_swap_scenarios.py -m live -v
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from agent_gen.cli import cli
+from agent_gen.librarian import HARNESS_ROOT
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _add_skill(root: Path, name: str, desc: str = "Test skill") -> None:
+    sd = root / HARNESS_ROOT / "skills" / name
+    sd.mkdir(parents=True, exist_ok=True)
+    (sd / "skill-manifest.json").write_text(
+        json.dumps({"name": name, "description": desc,
+                    "triggers": f"when you need {name}", "input": ""}),
+        encoding="utf-8",
+    )
+
+
+def _brief(adapter: str) -> Path:
+    return Path(f".ai/adapters/{adapter}/brief.md")
+
+
+def _read_brief(adapter: str) -> str:
+    return _brief(adapter).read_text(encoding="utf-8")
+
+
+def _you_are_here_row(content: str) -> str:
+    """Return the line containing ← YOU ARE HERE, or empty string."""
+    for line in content.splitlines():
+        if "← YOU ARE HERE" in line:
+            return line
+    return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Class A — init with each primary adapter
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestInitPrimary:
+    """init --primary <adapter> creates all root files + correct YOU ARE HERE."""
+
+    @pytest.mark.parametrize("adapter", ["claude", "codex", "gemini"])
+    def test_init_exit_zero(self, runner, adapter):
+        with runner.isolated_filesystem():
+            r = runner.invoke(cli, ["init", "--primary", adapter])
+            assert r.exit_code == 0, r.output
+
+    @pytest.mark.parametrize("adapter", ["claude", "codex", "gemini"])
+    def test_you_are_here_on_correct_row(self, runner, adapter):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", adapter])
+            content = _read_brief(adapter)
+            row = _you_are_here_row(content)
+            assert row, f"← YOU ARE HERE not found in {adapter} brief"
+            assert adapter in row, \
+                f"YOU ARE HERE row does not mention '{adapter}': {row!r}"
+
+    @pytest.mark.parametrize("adapter", ["claude", "codex", "gemini"])
+    def test_you_are_here_appears_exactly_once(self, runner, adapter):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", adapter])
+            content = _read_brief(adapter)
+            assert content.count("← YOU ARE HERE") == 1
+
+    @pytest.mark.parametrize("adapter", ["claude", "codex", "gemini"])
+    def test_project_context_present(self, runner, adapter):
+        """## Project Context injected once preamble is written to AgentFactory.md."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", adapter])
+            # Write a preamble (fresh init leaves AF.md empty of preamble)
+            af = Path(".ai/AgentFactory.md")
+            original = af.read_text(encoding="utf-8")
+            af.write_text("## Overview\n\nTest project description.\n\n" + original,
+                          encoding="utf-8")
+            runner.invoke(cli, ["brief"])
+            content = _read_brief(adapter)
+            assert "## Project Context" in content, \
+                f"## Project Context missing from {adapter} brief"
+
+    @pytest.mark.parametrize("adapter,root_files", [
+        ("claude", ["CLAUDE.md"]),
+        ("codex",  ["AGENTS.md", "CODEX.md"]),
+        ("gemini", ["GEMINI.md"]),
+    ])
+    def test_root_files_exist_for_primary(self, runner, adapter, root_files):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", adapter])
+            for f in root_files:
+                assert Path(f).is_symlink(), f"{f} not a symlink after init --primary {adapter}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Class B — directed swap scenarios (all 6 ordered pairs)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAdapterSwap:
+    """Init with one adapter then activate a second. Verify YOU ARE HERE and root files."""
+
+    def _swap(self, runner, init_primary: str, add_adapter: str):
+        runner.invoke(cli, ["init", "--primary", init_primary])
+        r = runner.invoke(cli, ["adapter", "add", add_adapter])
+        assert r.exit_code == 0, r.output
+        runner.invoke(cli, ["brief"])
+        return _read_brief(add_adapter)
+
+    def test_claude_to_codex(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "claude", "codex")
+            row = _you_are_here_row(content)
+            assert "codex" in row
+            assert Path("AGENTS.md").is_symlink()
+            assert Path("CODEX.md").is_symlink()
+
+    def test_claude_to_gemini(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "claude", "gemini")
+            row = _you_are_here_row(content)
+            assert "gemini" in row
+            assert Path("GEMINI.md").is_symlink()
+
+    def test_codex_to_claude(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "codex", "claude")
+            row = _you_are_here_row(content)
+            assert "claude" in row
+            assert Path("CLAUDE.md").is_symlink()
+
+    def test_codex_to_gemini(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "codex", "gemini")
+            row = _you_are_here_row(content)
+            assert "gemini" in row
+            assert Path("GEMINI.md").is_symlink()
+
+    def test_gemini_to_claude(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "gemini", "claude")
+            row = _you_are_here_row(content)
+            assert "claude" in row
+            assert Path("CLAUDE.md").is_symlink()
+
+    def test_gemini_to_codex(self, runner):
+        with runner.isolated_filesystem():
+            content = self._swap(runner, "gemini", "codex")
+            row = _you_are_here_row(content)
+            assert "codex" in row
+            assert Path("AGENTS.md").is_symlink()
+            assert Path("CODEX.md").is_symlink()
+
+    def test_swap_preserves_init_adapter_brief(self, runner):
+        """Adding a second adapter must not corrupt the first adapter's brief."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "claude"])
+            runner.invoke(cli, ["adapter", "add", "codex"])
+            runner.invoke(cli, ["brief"])
+            claude_content = _read_brief("claude")
+            row = _you_are_here_row(claude_content)
+            assert "claude" in row, "claude brief YOU ARE HERE row corrupted after adding codex"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Class C — three-way lifecycle from each starting adapter
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestThreeWayLifecycle:
+    """Init with A, add B, add C, recompile. Each brief must have exactly one YOU ARE HERE."""
+
+    def _full_lifecycle(self, runner, primary: str):
+        """Activate all three adapters starting from `primary`. Return dict of brief contents."""
+        others = [a for a in ["claude", "codex", "gemini"] if a != primary]
+        runner.invoke(cli, ["init", "--primary", primary])
+        for other in others:
+            runner.invoke(cli, ["adapter", "add", other])
+        runner.invoke(cli, ["brief"])
+        return {a: _read_brief(a) for a in ["claude", "codex", "gemini"]}
+
+    @pytest.mark.parametrize("primary", ["claude", "codex", "gemini"])
+    def test_each_brief_has_exactly_one_you_are_here(self, runner, primary):
+        with runner.isolated_filesystem():
+            briefs = self._full_lifecycle(runner, primary)
+            for adapter, content in briefs.items():
+                count = content.count("← YOU ARE HERE")
+                assert count == 1, \
+                    f"{adapter} brief has {count} YOU ARE HERE markers (expected 1)"
+
+    @pytest.mark.parametrize("primary", ["claude", "codex", "gemini"])
+    def test_each_brief_you_are_here_on_own_row(self, runner, primary):
+        with runner.isolated_filesystem():
+            briefs = self._full_lifecycle(runner, primary)
+            for adapter, content in briefs.items():
+                row = _you_are_here_row(content)
+                assert adapter in row, \
+                    f"{adapter} brief YOU ARE HERE on wrong row: {row!r}"
+
+    @pytest.mark.parametrize("primary", ["claude", "codex", "gemini"])
+    def test_all_three_adapters_in_cross_table(self, runner, primary):
+        """Cross-adapter table in every brief lists all three adapters."""
+        with runner.isolated_filesystem():
+            briefs = self._full_lifecycle(runner, primary)
+            for adapter, content in briefs.items():
+                for listed in ["claude", "codex", "gemini"]:
+                    assert listed in content, \
+                        f"{adapter} brief missing '{listed}' from cross-adapter table"
+
+    @pytest.mark.parametrize("primary", ["claude", "codex", "gemini"])
+    def test_all_root_files_present(self, runner, primary):
+        with runner.isolated_filesystem():
+            self._full_lifecycle(runner, primary)
+            for f in ["CLAUDE.md", "AGENTS.md", "CODEX.md", "GEMINI.md"]:
+                assert Path(f).is_symlink(), f"{f} missing after full lifecycle from {primary}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Class D — adapter-specific format and content assertions
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBriefContentAssertions:
+    """Structural and format checks per adapter."""
+
+    def test_claude_has_commands_section(self, runner):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "claude"])
+            content = _read_brief("claude")
+            assert "## Commands" in content
+
+    def test_codex_has_no_commands_section(self, runner):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "codex"])
+            content = _read_brief("codex")
+            assert "## Commands" not in content
+
+    def test_gemini_has_no_commands_section(self, runner):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "gemini"])
+            content = _read_brief("gemini")
+            assert "## Commands" not in content
+
+    def test_gemini_has_available_tools_header(self, runner):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "gemini"])
+            content = _read_brief("gemini")
+            assert "## Available Tools" in content
+
+    def test_all_briefs_reference_agentfactory_md(self, runner):
+        """Harness identity block must mention .ai/AgentFactory.md in every brief."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init"])
+            for adapter in ["claude", "codex", "gemini"]:
+                content = _read_brief(adapter)
+                assert "AgentFactory.md" in content, \
+                    f"AgentFactory.md reference missing from {adapter} brief"
+
+    def test_all_briefs_have_rules_section(self, runner):
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init"])
+            for adapter in ["claude", "codex", "gemini"]:
+                content = _read_brief(adapter)
+                assert "## Behavior Rules" in content, \
+                    f"## Behavior Rules missing from {adapter} brief"
+
+    def test_section_order_harness_before_context_before_skills(self, runner):
+        """## Harness must precede ## Project Context which must precede skills section."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init"])
+            # Write preamble so ## Project Context is injected
+            af = Path(".ai/AgentFactory.md")
+            original = af.read_text(encoding="utf-8")
+            af.write_text("## Overview\n\nTest project description.\n\n" + original,
+                          encoding="utf-8")
+            runner.invoke(cli, ["brief"])
+            for adapter in ["claude", "codex", "gemini"]:
+                content = _read_brief(adapter)
+                harness_pos = content.find("## Harness")
+                context_pos = content.find("## Project Context")
+                skills_pos = max(
+                    content.find("## Available Skills"),
+                    content.find("## Available Tools"),
+                    content.find("## Skills"),
+                )
+                assert harness_pos < context_pos < skills_pos, (
+                    f"{adapter} brief section order wrong: "
+                    f"Harness@{harness_pos}, Context@{context_pos}, Skills@{skills_pos}"
+                )
+
+    def test_codex_context_truncation_when_preamble_large(self, runner):
+        """If preamble exceeds 2000 chars, codex brief gets truncation warning comment."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "codex"])
+            # Write a large preamble into AgentFactory.md
+            af_path = Path(".ai/AgentFactory.md")
+            original = af_path.read_text(encoding="utf-8")
+            marker = original.find("<!-- @")
+            # Inject a large preamble block before the first marker
+            padding = "A" * 2500
+            preamble_block = f"\n## Large Context\n\n{padding}\n\n"
+            if marker > 0:
+                new_content = original[:marker] + preamble_block + original[marker:]
+            else:
+                new_content = original + preamble_block
+            af_path.write_text(new_content, encoding="utf-8")
+            # Recompile
+            runner.invoke(cli, ["brief"])
+            content = _read_brief("codex")
+            assert "context truncated" in content, \
+                "Codex brief should contain truncation warning when preamble > 2000 chars"
+
+    def test_claude_no_truncation_warning_when_preamble_within_budget(self, runner):
+        """Claude 4000-char budget — default preamble should not be truncated."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "claude"])
+            content = _read_brief("claude")
+            assert "context truncated" not in content
+
+    def test_cross_adapter_table_complete_even_with_one_adapter(self, runner):
+        """Even a claude-only init still lists codex and gemini rows in the table."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "claude"])
+            content = _read_brief("claude")
+            assert "codex" in content
+            assert "gemini" in content
+
+    def test_agentfactory_md_gets_rules_and_commands_sections(self, runner):
+        """After brief recompile, AgentFactory.md has @rules and @commands marker blocks."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init"])
+            runner.invoke(cli, ["brief"])
+            af = Path(".ai/AgentFactory.md").read_text(encoding="utf-8")
+            assert "<!-- @rules-start -->" in af, \
+                "AgentFactory.md missing <!-- @rules-start --> after brief recompile"
+            assert "<!-- @commands-start -->" in af, \
+                "AgentFactory.md missing <!-- @commands-start --> after brief recompile"
+
+    def test_skill_appears_in_all_adapter_briefs_after_swap(self, runner):
+        """A skill added before a swap must appear in the new adapter's brief."""
+        with runner.isolated_filesystem():
+            runner.invoke(cli, ["init", "--primary", "claude"])
+            _add_skill(Path("."), "my-workflow", "Automates the deployment workflow")
+            runner.invoke(cli, ["adapter", "add", "codex"])
+            runner.invoke(cli, ["brief"])
+            for adapter in ["claude", "codex"]:
+                content = _read_brief(adapter)
+                assert "my-workflow" in content, \
+                    f"Skill 'my-workflow' missing from {adapter} brief after swap"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 2 — live agent invocation (pytest -m live)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Probe prompt sent to each agent. Short enough to get a fast response,
+# specific enough to verify the agent has read the harness brief.
+_PROBE_PROMPT = (
+    "What harness root does this project use? "
+    "What adapter are you running in? "
+    "Name one available skill."
+)
+
+# Best-effort CLI flags per agent. Users should verify for their installed version.
+_CLI_INVOCATION = {
+    "claude": ["claude", "--print", _PROBE_PROMPT],
+    "codex":  ["codex",  "exec", "--skip-git-repo-check", _PROBE_PROMPT],
+    "gemini": ["gemini", "--prompt", _PROBE_PROMPT],
+}
+
+# Keywords that a well-briefed agent should mention.
+_EXPECTED_KEYWORDS = {
+    "claude": [".ai"],
+    "codex":  [".ai"],
+    "gemini": [".ai"],
+}
+
+
+@pytest.mark.live
+@pytest.mark.parametrize("adapter", ["claude", "codex", "gemini"])
+def test_live_agent_acknowledges_harness(adapter, runner, tmp_path):
+    """
+    Invoke the real CLI agent in a fresh project and assert it acknowledges the
+    AgentFactory harness context from its compiled brief.
+
+    Skipped automatically when the CLI is not installed.
+    """
+    if not shutil.which(adapter):
+        pytest.skip(f"{adapter} CLI not installed")
+
+    proj = tmp_path / "live_proj"
+    proj.mkdir()
+
+    # Init project in tmp_path
+    r = runner.invoke(cli, ["init", "--primary", adapter, "--project-root", str(proj)])
+    assert r.exit_code == 0, f"init failed: {r.output}"
+
+    # Add a recognisable skill so there's something concrete to mention
+    _add_skill(proj, "deploy-pipeline", "Automates the CI/CD deploy pipeline")
+    r2 = runner.invoke(cli, ["brief", "--project-root", str(proj)])
+    assert r2.exit_code == 0, f"brief failed: {r2.output}"
+
+    # Invoke the live CLI from the project root
+    cmd = _CLI_INVOCATION[adapter]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(proj),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    response = (proc.stdout + proc.stderr).lower()
+
+    missing = [kw for kw in _EXPECTED_KEYWORDS[adapter] if kw.lower() not in response]
+    assert not missing, (
+        f"{adapter} live response did not mention: {missing}\n"
+        f"Response excerpt:\n{response[:800]}"
+    )

--- a/src/tests/test_librarian_lifecycle.py
+++ b/src/tests/test_librarian_lifecycle.py
@@ -2,7 +2,6 @@ import io
 import json
 import os
 import stat
-import sys
 import unittest
 import tempfile
 import zipfile

--- a/src/tests/test_librarian_lifecycle.py
+++ b/src/tests/test_librarian_lifecycle.py
@@ -2,10 +2,12 @@ import io
 import json
 import os
 import stat
+import sys
 import unittest
 import tempfile
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 from agent_gen.librarian import (
     Librarian, MANIFEST_FILE, HARNESS_ROOT, CONTEXT_FILE, _safe_extract,
@@ -527,6 +529,60 @@ class TestProjectContextInjection(unittest.TestCase):
             brief = (root / HARNESS_ROOT / "adapters" / "claude" / "brief.md").read_text(encoding="utf-8")
             self.assertNotIn("context truncated", brief)
             self.assertIn("Short project description.", brief)
+
+    def test_oracle_called_when_key_set_and_truncated(self):
+        """Oracle runs when license key is set and preamble is truncated; score printed to stderr."""
+        long_preamble = ("B" * 500 + "\n\n") * 10
+        af_content = f"# Title\n\n{long_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            with patch("agent_gen.librarian._run_preamble_oracle", return_value=72) as mock_oracle:
+                with patch.dict(os.environ, {"AGENTFACTORY_LICENSE_KEY": "pro_testkey"}):
+                    Librarian._compile_adapter_briefs(str(root))
+                mock_oracle.assert_called()
+                call_args = mock_oracle.call_args
+                original, truncated, pr = call_args.args
+                self.assertGreater(len(original), len(truncated))
+                self.assertEqual(pr, str(root))
+
+    def test_oracle_not_called_without_key(self):
+        """Oracle is not invoked when AGENTFACTORY_LICENSE_KEY is absent."""
+        long_preamble = ("C" * 500 + "\n\n") * 10
+        af_content = f"# Title\n\n{long_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            env = {k: v for k, v in os.environ.items() if k != "AGENTFACTORY_LICENSE_KEY"}
+            with patch("agent_gen.librarian._run_preamble_oracle") as mock_oracle:
+                with patch.dict(os.environ, env, clear=True):
+                    Librarian._compile_adapter_briefs(str(root))
+                mock_oracle.assert_not_called()
+
+    def test_oracle_not_called_when_no_truncation(self):
+        """Oracle is not invoked when preamble fits within budget."""
+        short_preamble = "Fits easily.\n\nNo truncation needed."
+        af_content = f"# Title\n\n{short_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            with patch("agent_gen.librarian._run_preamble_oracle") as mock_oracle:
+                with patch.dict(os.environ, {"AGENTFACTORY_LICENSE_KEY": "pro_testkey"}):
+                    Librarian._compile_adapter_briefs(str(root))
+                mock_oracle.assert_not_called()
+
+    def test_oracle_error_does_not_crash_compilation(self):
+        """If the oracle raises, brief compilation still succeeds."""
+        long_preamble = ("D" * 500 + "\n\n") * 10
+        af_content = f"# Title\n\n{long_preamble}\n\n<!-- @agent-registry:start -->\n<!-- @agent-registry:end -->\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_harness(root, af_content)
+            with patch("agent_gen.librarian._run_preamble_oracle", side_effect=Exception("api down")):
+                with patch.dict(os.environ, {"AGENTFACTORY_LICENSE_KEY": "pro_testkey"}):
+                    Librarian._compile_adapter_briefs(str(root))
+            brief = (root / HARNESS_ROOT / "adapters" / "codex" / "brief.md").read_text(encoding="utf-8")
+            self.assertIn("context truncated", brief)
 
     def test_compile_agentfactory_md_adds_rules_and_commands(self):
         """After _compile_adapter_briefs, AgentFactory.md contains rules + commands blocks."""


### PR DESCRIPTION
## Summary

- Wires the completeness oracle into `_fit_context_to_budget` so it runs automatically when a preamble is truncated and `AGENTFACTORY_LICENSE_KEY` is set
- Score printed to stderr as `⚠ preamble completeness: X%` — advisory only, never blocks compilation or changes brief content
- Threads `project_root` through `_render_brief` → `_fit_context_to_budget` to locate the oracle script
- Oracle loaded via `importlib` (no subprocess, no argparser changes to `skill-completeness-check.py`)
- Double `try/except` containment ensures oracle failures never surface to the caller

## Closes

Closes #126

## Test plan

- [x] `test_oracle_called_when_key_set_and_truncated` — oracle invoked with correct args when license key present and preamble over budget
- [x] `test_oracle_not_called_without_key` — oracle skipped when no `AGENTFACTORY_LICENSE_KEY`
- [x] `test_oracle_not_called_when_no_truncation` — oracle skipped when preamble fits within budget
- [x] `test_oracle_error_does_not_crash_compilation` — brief still written when oracle raises
- [x] Full suite: 263 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)