### PR TITLE
feat: agentfactory-gen publish + import --from-registry (#82)

### DIFF
--- a/.ai/memory/milestones.md
+++ b/.ai/memory/milestones.md
@@ -1,5 +1,5 @@
 # Milestones
-<!-- version: 1.7.7 -->
+<!-- version: 1.7.9 -->
 
 Living traceability matrix for all AgentFactory GitHub issues.
 Update this file on every PR merge and release (see git-versioning SKILL.md Step 8.5).
@@ -83,7 +83,7 @@ The CLI stays open-source. The platform is the paid surface.
 | #79 | feat[P1]: harness explorer UI — two-panel file tree + doc pane | webapp | moved→webapp-repo | — | — | — | — |
 | #80 | feat[P1]: lifecycle stepper + manifest inspector UI components | webapp | moved→webapp-repo | feature/80-lifecycle-stepper-manifest-inspector | #112 | cf35f7a | — |
 | #81 | feat[P1]: public agent registry — browse, search, publish Portable Units | registry | done | feature/81-public-agent-registry | #111 | 17ae0e3 | — |
-| #82 | feat[P1]: CLI extensions — agentfactory-gen publish + import --from-registry | cli | pending | — | — | — | — |
+| #82 | feat[P1]: CLI extensions — agentfactory-gen publish + import --from-registry | cli | in-progress | feature/82-cli-publish-import-registry | #129 | — | — |
 
 ### Phase 2 — Auth & Workspaces
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Branch protection on `dev` requires **Tests + Coverage** to pass before merge.
 | [`docs/FEATURE-AUTH.md`](docs/FEATURE-AUTH.md) | GitHub + Google OAuth system: states, API contract, plan gating |
 | [`docs/FEATURE-AGENTFACTORY-MD-BRIEF.md`](docs/FEATURE-AGENTFACTORY-MD-BRIEF.md) | Master brief & project context injection: workflow diagrams, gap analysis, CLI switch walkthrough |
 | [`docs/FEATURE-HARNESS-IDENTITY.md`](docs/FEATURE-HARNESS-IDENTITY.md) | Cross-adapter navigation block: how it works, swap walkthrough |
+| [`docs/FEATURE-REGISTRY-CLI.md`](docs/FEATURE-REGISTRY-CLI.md) | Registry CLI commands: `publish` upload flow, `import --from-registry` download flow, all scenarios |
 | [`docs/FEATURE-DOC-TEMPLATE.md`](docs/FEATURE-DOC-TEMPLATE.md) | Blank template — every new feature ships one of these |
 | [`docs/ISSUE-PRIORITY.md`](docs/ISSUE-PRIORITY.md) | Live issue priority + wave map (auto-regenerated on every merge) |
 | [`docs/SPEC.md`](docs/SPEC.md) | Technical specification: manifest schema, intelligence layer |

--- a/docs/FEATURE-REGISTRY-CLI.md
+++ b/docs/FEATURE-REGISTRY-CLI.md
@@ -1,0 +1,566 @@
+# Registry CLI — publish & import --from-registry
+<!-- version: 1.0.0 -->
+
+Issue: #82 · Phase 1 Foundation of the AgentFactory production platform (#77)
+
+Two CLI commands that connect `agentfactory-gen` to the public agent registry: `publish` uploads a wrapped agent, and `import --from-registry` downloads and installs one.
+
+---
+
+## 1. Overview
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  PURPOSE                                                               │
+  │                                                                        │
+  │  Agents wrapped as Portable Units (.zip) can now be shared via the   │
+  │  public registry at agentfactory.dev without manual file transfer.   │
+  │                                                                        │
+  │  What it unlocks:                                                      │
+  │    · agentfactory-gen login / logout CLI auth    (#86)                │
+  │    · private org workspaces + RBAC               (#84)                │
+  │    · marketplace — paid agent listings           (#90)                │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+The registry CLI sits on top of the existing wrap/import pipeline. `publish` reads from a ZIP that `wrap` already created; `import --from-registry` downloads a ZIP and feeds it into the same `unpack → audit → register` path that `import <zip>` already uses. No new librarian logic was introduced — only the HTTP transport layer is new.
+
+Dependency chain:
+```
+  #81 registry backend (done)
+       │
+       ▼
+  #82 CLI publish + import --from-registry  ← this feature
+       │
+       ├──► #86 agentfactory-gen login / logout
+       └──► #84 private workspaces (--private flag, Phase 2)
+```
+
+---
+
+## 2. Architecture
+
+### 2.1 File layout
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  FILE LAYOUT                                                           │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  src/agent_gen/cli.py
+    ├── REGISTRY_URL                      ← base URL constant (env-overridable)
+    ├── _registry_publish(manifest, zip)  ← POST multipart to /registry/publish
+    ├── _registry_fetch(slug)             ← GET entry + download ZIP bytes
+    ├── _attach_auth_header(req)          ← reads ~/.agentfactory/token if present
+    ├── publish  command                  ← new CLI command
+    └── import   command                  ← extended with --from-registry
+
+  ~/.agentfactory/token                   ← auth token (written by login, Phase 2)
+```
+
+### 2.2 Command structure
+
+```
+  agentfactory-gen
+   │
+   ├── publish <name>
+   │     ├── --version OVERRIDE    override the version from manifest
+   │     └── --tag TAG             discovery tag (repeatable)
+   │
+   └── import [ZIP_PATH]
+         ├── --from-git URL        clone + retrofit + import
+         └── --from-registry SLUG  download from registry + import  ← new
+               supports: my-agent
+                         my-agent@1.2.0   (pinned version)
+```
+
+### 2.3 HTTP layer
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  HTTP LAYER                                                            │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  _registry_publish()
+    POST {REGISTRY_URL}/registry/publish
+    Content-Type: multipart/form-data; boundary=AgentFactoryBoundary
+    Authorization: Bearer <token>  (if ~/.agentfactory/token exists)
+
+    Body parts:
+      ├── name="manifest"   Content-Type: application/json
+      │     { "name": "...", "version": "...", "description": "...", "tags": [...] }
+      └── name="file"       Content-Type: application/zip
+            filename=<name>-v<version>.zip
+
+  _registry_fetch()
+    GET {REGISTRY_URL}/registry/<name>[/<version>]
+    Authorization: Bearer <token>  (if present)
+    → 200: { "name": "...", "version": "...", "zip_url": "https://..." }
+    → 404: ClickException "Agent '<slug>' not found"
+
+    Then: GET <zip_url> (no auth — presigned URL or CDN)
+    → bytes written to NamedTemporaryFile, fed into existing import pipeline
+```
+
+---
+
+## 3. Configuration
+
+### 3.1 Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AGENTFACTORY_REGISTRY_URL` | No | `https://agentfactory.dev` | Override for self-hosted registry |
+
+### 3.2 Auth token
+
+```
+  ~/.agentfactory/token       ← plain text, single line: the JWT or API key
+                                 written by: agentfactory-gen login  (Phase 2, #86)
+                                 read by:    _attach_auth_header()
+                                 absent:     commands work for public registry
+                                             (unauthenticated reads / writes rejected by server)
+```
+
+---
+
+## 4. How It Works
+
+### 4.1 Publish flow
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  PUBLISH FLOW                                                          │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  agentfactory-gen publish my-agent [--version X] [--tag T]
+       │
+       ▼
+  Load  .ai/agents/my-agent/agent-manifest.json
+       │
+       ├── description == "" ?
+       │     YES → ClickException "description required"  ✗ STOP
+       │     NO  → continue
+       │
+       ▼
+  version = --version override  OR  manifest["version"]
+  zip_name = my-agent-v{version}.zip
+       │
+       ├── ./{zip_name} exists?
+       │     NO  → ClickException "run wrap first"  ✗ STOP
+       │     YES → continue
+       │
+       ▼
+  Build publish manifest:
+    { name, version, description, tags: [...] }
+       │
+       ▼
+  _attach_auth_header()  →  add Bearer token if ~/.agentfactory/token present
+       │
+       ▼
+  POST {REGISTRY_URL}/registry/publish
+    multipart: manifest JSON  +  ZIP binary
+       │
+       ├── HTTPError  → ClickException "Registry error <code>: <detail>"
+       ├── URLError   → ClickException "Registry unreachable: <reason>"
+       └── 200 OK     → continue
+       │
+       ▼
+  echo "Published: {REGISTRY_URL}/registry/my-agent@{version}"  ✓ DONE
+```
+
+### 4.2 Import --from-registry flow
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  IMPORT --FROM-REGISTRY FLOW                                           │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  agentfactory-gen import --from-registry my-agent[@version]
+       │
+       ▼
+  Validate mutual exclusion
+  (ZIP_PATH / --from-git / --from-registry are exclusive)
+       │
+       ▼
+  echo "Fetching 'my-agent' from registry..."
+       │
+       ▼
+  _registry_fetch("my-agent[@version]")
+    ├── parse slug: name="my-agent", version=None or "1.2.0"
+    ├── GET {REGISTRY_URL}/registry/my-agent[/1.2.0]
+    │     ├── 404 → ClickException "not found"  ✗ STOP
+    │     └── 200 → entry = { name, version, zip_url }
+    └── GET entry["zip_url"]  →  zip_bytes
+       │
+       ▼
+  Write zip_bytes → NamedTemporaryFile (suffix=".zip", delete=False)
+  _cleanup = lambda: os.unlink(tmp.name)
+       │
+       ▼
+  ─ ─ ─ ─ ─ ─  Existing import pipeline  ─ ─ ─ ─ ─ ─
+       │
+       ▼
+  Peek archive → read agent-manifest.json → name
+       │
+       ├── .ai/agents/{name}/ exists?
+       │     YES → sys.exit(1) "already exists"  ✗ STOP
+       │     NO  → continue
+       │
+       ▼
+  Librarian.unpack(zip_path, temp_dir/{name})
+       │
+       ▼
+  librarian.audit()
+       │
+       ├── broken_resources / broken_dependencies / invalid_skill_manifests?
+       │     YES → sys.exit(1) "Audit FAILED"  ✗ STOP
+       │     NO  → continue
+       │
+       ▼
+  shutil.move(temp_dir/{name} → .ai/agents/{name})
+       │
+       ▼
+  Librarian.register_in_project(manifest, project_root)
+       │
+       ▼
+  _cleanup()  →  delete NamedTemporaryFile
+       │
+       ▼
+  Print summary: N skills, N commands, ...  ✓ DONE
+```
+
+### 4.3 Auth token attachment
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  AUTH FLOW                                                             │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  _attach_auth_header(req)
+       │
+       ├── ~/.agentfactory/token  exists?
+       │     NO  → do nothing (unauthenticated request)
+       │     YES → req.add_header("Authorization", "Bearer <token>")
+       │
+       ▼
+  Caller proceeds with urllib.request.urlopen(req)
+```
+
+---
+
+## 5. Usage Examples
+
+### 5.1 Full publish lifecycle (from scratch)
+
+```bash
+# 1. Create and describe the agent
+agentfactory-gen deploy my-agent
+agentfactory-gen describe my-agent --desc "A natural language search agent"
+
+# 2. Add content to skills/, scripts/ etc., then wrap
+agentfactory-gen wrap my-agent
+
+# 3. Publish to the registry
+agentfactory-gen publish my-agent
+# Published: https://agentfactory.dev/registry/my-agent@1.0.0
+```
+
+### 5.2 Publish with version override and tags
+
+```bash
+agentfactory-gen publish my-agent --version 1.2.0 --tag nlp --tag retrieval
+# Looks for: my-agent-v1.2.0.zip in cwd
+# Published: https://agentfactory.dev/registry/my-agent@1.2.0
+```
+
+### 5.3 Import latest version of an agent
+
+```bash
+agentfactory-gen import --from-registry my-agent
+# Fetches latest, installs to .ai/agents/my-agent/
+```
+
+### 5.4 Import a pinned version
+
+```bash
+agentfactory-gen import --from-registry my-agent@1.2.0
+# Fetches exactly v1.2.0
+```
+
+### 5.5 Quiet mode (CI / scripts)
+
+```bash
+agentfactory-gen --quiet publish my-agent
+agentfactory-gen --quiet import --from-registry my-agent
+```
+
+### 5.6 Self-hosted registry
+
+```bash
+export AGENTFACTORY_REGISTRY_URL=https://registry.internal.example.com
+agentfactory-gen publish my-agent
+agentfactory-gen import --from-registry my-agent
+```
+
+### 5.7 Combine --project-root with --from-registry
+
+```bash
+agentfactory-gen import --from-registry my-agent --project-root /path/to/project
+```
+
+---
+
+## 6. All Scenarios
+
+### Scenario 1 — Happy path: first publish
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 1: FIRST PUBLISH                                             │
+  │  Pre-condition: agent deployed, described, wrapped                     │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── publish my-agent ─────►│                            │
+      │                          │── load manifest            │
+      │                          │── check description ✓      │
+      │                          │── find my-agent-v1.0.0.zip │
+      │                          │── POST /registry/publish ─►│
+      │                          │                            │── store ZIP
+      │                          │◄── 200 OK ─────────────────│
+      │◄── Published: .../my-agent@1.0.0 ────────────────────│
+```
+
+### Scenario 2 — Republish with new version
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 2: REPUBLISH WITH NEW VERSION                                │
+  │  Pre-condition: agent already published at v1.0.0                     │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │  (edit agent files)      │                            │
+      │── wrap my-agent ────────►│── creates my-agent-v1.1.0.zip          │
+      │                          │                            │
+      │── publish my-agent ─────►│                            │
+      │    --version 1.1.0       │── finds my-agent-v1.1.0.zip            │
+      │                          │── POST /registry/publish ─►│
+      │◄── Published: .../my-agent@1.1.0 ─────────────────────│
+
+  Note: --version must match the ZIP name on disk.
+  If wrapping to a non-default version, use:
+    agentfactory-gen wrap my-agent  (updates manifest version first)
+```
+
+### Scenario 3 — Import latest version
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 3: IMPORT LATEST                                             │
+  │  Pre-condition: agent not yet in .ai/agents/                          │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── import                 │                            │
+      │    --from-registry ─────►│                            │
+      │    my-agent              │── GET /registry/my-agent ─►│
+      │                          │◄── { zip_url: "..." } ─────│
+      │                          │── GET <zip_url> ───────────►CDN
+      │                          │◄── ZIP bytes ──────────────│
+      │                          │── write temp file          │
+      │                          │── unpack → audit → register│
+      │◄── Import Complete ───────│                            │
+      │    .ai/agents/my-agent/  │                            │
+```
+
+### Scenario 4 — Import pinned version
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 4: IMPORT PINNED VERSION                                     │
+  │  Slug format: <name>@<version>                                         │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── import                 │                            │
+      │    --from-registry ─────►│                            │
+      │    my-agent@1.2.0        │── parse: name="my-agent"  │
+      │                          │          version="1.2.0"  │
+      │                          │── GET /registry/my-agent/1.2.0 ───────►│
+      │                          │◄── { version:"1.2.0", zip_url } ───────│
+      │                          │── download + install v1.2.0            │
+      │◄── Imported my-agent v1.2.0 ──────────────────────────│
+```
+
+### Scenario 5 — Error: not wrapped yet
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 5: PUBLISH BEFORE WRAP                                       │
+  │  Pre-condition: agent deployed but wrap never run                      │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI
+      │                          │
+      │── publish my-agent ─────►│── load manifest ✓
+      │                          │── check description ✓
+      │                          │── find my-agent-v1.0.0.zip
+      │                          │     NOT FOUND  ✗
+      │◄── Error ─────────────────│
+      │  "No wrapped archive found: my-agent-v1.0.0.zip
+      │   Run 'agentfactory-gen wrap my-agent' first."
+
+  Fix: agentfactory-gen wrap my-agent
+```
+
+### Scenario 6 — Error: missing description
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 6: MISSING DESCRIPTION                                       │
+  │  Pre-condition: manifest description is empty string                   │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI
+      │                          │
+      │── publish my-agent ─────►│── load manifest ✓
+      │                          │── check description
+      │                          │     description == ""  ✗
+      │◄── Error ─────────────────│
+      │  "Manifest 'description' is required for publishing.
+      │   Run 'agentfactory-gen describe my-agent --desc \"...\"' first."
+
+  Note: No HTTP call is made. Validation is fully local.
+  Fix:  agentfactory-gen describe my-agent --desc "What this agent does"
+```
+
+### Scenario 7 — Error: agent already imported
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 7: AGENT ALREADY EXISTS                                      │
+  │  Pre-condition: .ai/agents/my-agent/ already present                  │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── import                 │                            │
+      │    --from-registry ─────►│── GET /registry/my-agent ─►│
+      │    my-agent              │◄── 200 + zip_url ──────────│
+      │                          │── download ZIP             │
+      │                          │── peek manifest → name="my-agent"
+      │                          │── check .ai/agents/my-agent/
+      │                          │     EXISTS  ✗
+      │◄── Error (stderr) ────────│
+      │  "'my-agent' already exists at .ai/agents/my-agent.
+      │   Remove it first or rename the incoming bundle."
+
+  Fix: agentfactory-gen uninstall my-agent
+       agentfactory-gen import --from-registry my-agent
+```
+
+### Scenario 8 — Error: network failure or 404
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SCENARIO 8: NETWORK FAILURE / NOT FOUND                               │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  8a. Slug not found (404)
+  ─────────────────────────────────────────────────────────────────────
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── import                 │                            │
+      │    --from-registry ─────►│── GET /registry/typo-name ►│
+      │    typo-name             │                            │── 404
+      │                          │◄── HTTPError 404 ───────────│
+      │◄── Error: "Agent 'typo-name' not found in registry."  │
+
+  8b. Registry unreachable
+  ─────────────────────────────────────────────────────────────────────
+  Developer                    CLI
+      │                          │
+      │── publish my-agent ─────►│── POST /registry/publish
+      │                          │     URLError (connection refused / timeout)
+      │◄── Error: "Registry unreachable: <reason>"
+
+  8c. Auth error (401)
+  ─────────────────────────────────────────────────────────────────────
+  Developer                    CLI                        Registry
+      │                          │                            │
+      │── publish my-agent ─────►│── POST /registry/publish ─►│
+      │                          │                            │── 401
+      │◄── Error: "Registry error 401: Unauthorized"
+      │
+      Cause: token missing, expired, or revoked
+      Fix:   agentfactory-gen login   (Phase 2, #86)
+```
+
+---
+
+## 7. Integration Points
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  INTEGRATION MAP                                                       │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Called by:
+    Developer CLI         ──►  publish, import --from-registry
+    CI/CD publish job     ──►  agentfactory-gen --quiet publish <name>
+
+  Calls:
+    publish  ──►  Librarian._load_manifest()          (agent manifest read)
+             ──►  _registry_publish()                  (HTTP POST)
+             ──►  _attach_auth_header()                (token injection)
+
+    import   ──►  _registry_fetch()                    (HTTP GET + download)
+             ──►  _attach_auth_header()                (token injection)
+             ──►  Librarian.unpack()                   (ZIP extraction)
+             ──►  librarian.audit()                    (integrity check)
+             ──►  Librarian.register_in_project()      (manifest update)
+
+  Unlocks (future phases):
+    publish --private  ──►  #84 private org workspaces
+    agentfactory-gen login  ──►  #86 writes ~/.agentfactory/token
+    marketplace listings    ──►  #90 paid agent listings
+```
+
+---
+
+## 8. Troubleshooting
+
+```
+  ┌──────────────────────────────────────────┬───────────────────────────────────────┐
+  │  Symptom                                  │  Fix                                   │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "No wrapped archive found: name-v*.zip" │  agentfactory-gen wrap <name>          │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "Manifest 'description' is required"    │  agentfactory-gen describe <name>      │
+  │                                           │    --desc "What this agent does"       │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "Registry unreachable"                  │  Check network connection              │
+  │                                           │  Verify AGENTFACTORY_REGISTRY_URL      │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "Registry error 401: Unauthorized"      │  agentfactory-gen login   (#86)        │
+  │                                           │  Or set ~/.agentfactory/token manually │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "Registry error 404" on publish         │  Registry endpoint config mismatch;   │
+  │                                           │  check AGENTFACTORY_REGISTRY_URL       │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "Agent '<name>' not found in registry"  │  Check slug spelling; browse           │
+  │                                           │  agentfactory.dev/registry             │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  "'<name>' already exists" on import     │  agentfactory-gen uninstall <name>     │
+  │                                           │  Then re-run import --from-registry    │
+  ├──────────────────────────────────────────┼───────────────────────────────────────┤
+  │  ZIP downloaded but audit fails          │  Agent bundle is corrupt or missing    │
+  │                                           │  required files; contact publisher     │
+  └──────────────────────────────────────────┴───────────────────────────────────────┘
+```

--- a/src/agent_gen/cli.py
+++ b/src/agent_gen/cli.py
@@ -1,16 +1,20 @@
 """agent-gen CLI — deploy, wrap, import."""
 
+import json
 import os
 import re
 import sys
 import shutil
 import subprocess
 import tempfile
+import zipfile
 from pathlib import Path
 
 import click
 
 from .librarian import TRACKED_DIRS, HARNESS_ROOT, CONTEXT_FILE, Librarian, _safe_extract, _FORMAT_REGISTRY
+
+REGISTRY_URL = os.environ.get("AGENTFACTORY_REGISTRY_URL", "https://agentfactory.dev")
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +112,93 @@ def _assert_within_root(rel_path: str, root: Path) -> None:
         raise click.ClickException(
             f"Path '{rel_path}' resolves outside the agent root — possible path traversal."
         )
+
+
+# ---------------------------------------------------------------------------
+# Registry HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _registry_publish(manifest: dict, zip_path: Path) -> dict:
+    """POST manifest JSON + ZIP to the registry. Returns the registry response."""
+    import urllib.request
+    import urllib.error
+
+    boundary = "AgentFactoryBoundary"
+    manifest_bytes = json.dumps(manifest).encode()
+    zip_bytes = zip_path.read_bytes()
+
+    parts = [
+        (
+            f"--{boundary}\r\nContent-Disposition: form-data; name=\"manifest\""
+            f"\r\nContent-Type: application/json\r\n\r\n".encode()
+            + manifest_bytes + b"\r\n"
+        ),
+        (
+            f"--{boundary}\r\nContent-Disposition: form-data; name=\"file\""
+            f"; filename=\"{zip_path.name}\"\r\nContent-Type: application/zip\r\n\r\n".encode()
+            + zip_bytes + b"\r\n"
+        ),
+        f"--{boundary}--\r\n".encode(),
+    ]
+    body = b"".join(parts)
+
+    req = urllib.request.Request(
+        f"{REGISTRY_URL}/registry/publish", data=body, method="POST"
+    )
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    _attach_auth_header(req)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = json.loads(exc.read().decode()).get("detail", exc.reason)
+        except Exception:
+            detail = exc.reason
+        raise click.ClickException(f"Registry error {exc.code}: {detail}")
+    except urllib.error.URLError as exc:
+        raise click.ClickException(f"Registry unreachable: {exc.reason}")
+
+
+def _registry_fetch(slug: str) -> tuple[dict, bytes]:
+    """GET agent entry from registry and download its ZIP. Returns (entry_dict, zip_bytes)."""
+    import urllib.request
+    import urllib.error
+
+    name, _, version = slug.partition("@")
+    path = f"/registry/{name}/{version}" if version else f"/registry/{name}"
+
+    req = urllib.request.Request(f"{REGISTRY_URL}{path}", method="GET")
+    _attach_auth_header(req)
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            entry = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise click.ClickException(f"Agent '{slug}' not found in registry.")
+        raise click.ClickException(f"Registry error {exc.code}: {exc.reason}")
+    except urllib.error.URLError as exc:
+        raise click.ClickException(f"Registry unreachable: {exc.reason}")
+
+    zip_url = entry.get("zip_url")
+    if not zip_url:
+        raise click.ClickException(f"Registry response missing 'zip_url' for '{slug}'.")
+
+    try:
+        with urllib.request.urlopen(zip_url, timeout=60) as resp:
+            zip_bytes = resp.read()
+    except urllib.error.URLError as exc:
+        raise click.ClickException(f"Failed to download agent ZIP: {exc.reason}")
+
+    return entry, zip_bytes
+
+
+def _attach_auth_header(req) -> None:
+    token_path = Path.home() / ".agentfactory" / "token"
+    if token_path.exists():
+        req.add_header("Authorization", f"Bearer {token_path.read_text().strip()}")
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +554,53 @@ def wrap(name: str, out: str):
     _echo(f"[librarian] Wrapped → {archive}")
 
 
+# ---------------------------------------------------------------------------
+# publish
+# ---------------------------------------------------------------------------
+
+@cli.command()
+@click.argument("name")
+@click.option("--version", "version_override", default=None, help="Override version from manifest.")
+@click.option("--tag", "tags", multiple=True, metavar="TAG", help="Discovery tag (repeatable).")
+def publish(name: str, version_override: str, tags: tuple):
+    """Upload a wrapped agent to the public registry."""
+    root = _agent_root(name)
+    librarian = Librarian(str(root))
+    manifest = librarian._load_manifest()
+
+    if not manifest.get("description"):
+        raise click.ClickException(
+            f"Manifest 'description' is required for publishing. "
+            f"Run 'agentfactory-gen describe {name} --desc \"...\"' first."
+        )
+
+    version = version_override or manifest.get("version", "0.1.0")
+    agent_name = manifest["name"]
+    zip_name = f"{agent_name}-v{version}.zip"
+    zip_path = Path.cwd() / zip_name
+
+    if not zip_path.exists():
+        raise click.ClickException(
+            f"No wrapped archive found: {zip_name}\n"
+            f"Run 'agentfactory-gen wrap {name}' first."
+        )
+
+    publish_manifest = {
+        "name": agent_name,
+        "version": version,
+        "description": manifest["description"],
+        "tags": list(tags),
+    }
+
+    _echo(f"[librarian] Publishing '{agent_name}@{version}' to registry...")
+    _registry_publish(publish_manifest, zip_path)
+    _echo(f"[librarian] Published: {REGISTRY_URL}/registry/{agent_name}@{version}")
+
+
+# ---------------------------------------------------------------------------
+# retrofit
+# ---------------------------------------------------------------------------
+
 @cli.command()
 @click.argument("path")
 @click.option("--yes", is_flag=True, help="Execute migration without asking for confirmation.")
@@ -612,16 +750,23 @@ def import_skill(path: str, target_agent: str):
     help="Git URL to clone, retrofit, and import as an agent (skips ZIP_PATH).",
 )
 @click.option(
+    "--from-registry",
+    "from_registry",
+    default=None,
+    metavar="SLUG",
+    help="Registry slug to download and import (e.g. my-agent or my-agent@1.2.0).",
+)
+@click.option(
     "--project-root",
     default=".",
     show_default=True,
     help="Root of the project receiving the import (for the Handshake).",
 )
-def import_agent(zip_path: str, from_git: str, project_root: str):
+def import_agent(zip_path: str, from_git: str, from_registry: str, project_root: str):
     """
     Unpack a portable agent bundle and register it in this project.
 
-    Accepts either a local ZIP_PATH or --from-git URL (git clone + auto-retrofit).
+    Accepts a local ZIP_PATH, --from-git URL, or --from-registry SLUG.
 
     Steps:
       1. Unpack <zip_path> into agents/<name>/
@@ -630,13 +775,23 @@ def import_agent(zip_path: str, from_git: str, project_root: str):
     """
     _cleanup = None
 
-    if not zip_path and not from_git:
-        raise click.UsageError("Provide either ZIP_PATH or --from-git URL.")
-    if zip_path and from_git:
-        raise click.UsageError("ZIP_PATH and --from-git are mutually exclusive.")
+    sources = [s for s in (zip_path, from_git, from_registry) if s is not None]
+    if len(sources) > 1:
+        raise click.UsageError("ZIP_PATH, --from-git, and --from-registry are mutually exclusive.")
+    if not sources:
+        raise click.UsageError("Provide either ZIP_PATH, --from-git URL, or --from-registry SLUG.")
 
     if from_git:
         zip_path, _cleanup = _clone_and_prepare(from_git)
+
+    if from_registry:
+        _echo(f"[librarian] Fetching '{from_registry}' from registry...")
+        _entry, zip_bytes = _registry_fetch(from_registry)
+        tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        tmp.write(zip_bytes)
+        tmp.close()
+        zip_path = tmp.name
+        _cleanup = lambda p=tmp.name: os.unlink(p)  # noqa: E731
 
     zip_path = Path(zip_path).resolve()
 
@@ -645,9 +800,6 @@ def import_agent(zip_path: str, from_git: str, project_root: str):
         sys.exit(1)
 
     # Peek at the archive to get the agent name before unpacking
-    import zipfile
-    import json
-
     with zipfile.ZipFile(zip_path) as zf:
         with zf.open("agent-manifest.json") as mf:
             peeked = json.load(mf)
@@ -662,9 +814,6 @@ def import_agent(zip_path: str, from_git: str, project_root: str):
             err=True,
         )
         sys.exit(1)
-
-    import tempfile
-    import shutil
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_root = Path(temp_dir) / name

--- a/src/tests/test_registry.py
+++ b/src/tests/test_registry.py
@@ -1,0 +1,196 @@
+"""Tests for agentfactory-gen publish and import --from-registry commands."""
+
+import io
+import json
+import os
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from agent_gen.cli import cli, REGISTRY_URL
+from agent_gen.librarian import HARNESS_ROOT, MANIFEST_FILE
+
+AGENTS = f"{HARNESS_ROOT}/agents"
+
+
+def _setup_agent(runner, name: str, description: str = "A test agent") -> None:
+    """Deploy and describe an agent in the current isolated filesystem."""
+    runner.invoke(cli, ["deploy", name])
+    Path(f"{AGENTS}/{name}/skills/skill.md").touch()
+    if description:
+        runner.invoke(cli, ["describe", name, "--desc", description])
+
+
+class TestPublishCommand(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_publish_missing_zip_fails(self):
+        """publish should fail with a clear message when the ZIP hasn't been created yet."""
+        with self.runner.isolated_filesystem():
+            _setup_agent(self.runner, "pub-agent")
+            result = self.runner.invoke(cli, ["publish", "pub-agent"])
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("pub-agent-v1.0.0.zip", result.output)
+            self.assertIn("wrap", result.output)
+
+    def test_publish_missing_description_fails(self):
+        """publish should reject a manifest with an empty description."""
+        with self.runner.isolated_filesystem():
+            runner = self.runner
+            runner.invoke(cli, ["deploy", "nodesc-agent"])
+            Path(f"{AGENTS}/nodesc-agent/skills/skill.md").touch()
+            # Blank the description directly in the manifest file
+            mp = Path(f"{AGENTS}/nodesc-agent/agent-manifest.json")
+            m = json.loads(mp.read_text())
+            m["description"] = ""
+            mp.write_text(json.dumps(m))
+            runner.invoke(cli, ["wrap", "nodesc-agent"])
+            result = runner.invoke(cli, ["publish", "nodesc-agent"])
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("description", result.output)
+
+    def test_publish_success(self):
+        """publish should POST to registry and print the registry URL."""
+        with self.runner.isolated_filesystem():
+            _setup_agent(self.runner, "good-agent")
+            self.runner.invoke(cli, ["wrap", "good-agent"])
+
+            mock_response = {"slug": "good-agent", "version": "1.0.0"}
+            with patch("agent_gen.cli._registry_publish", return_value=mock_response) as mock_pub:
+                result = self.runner.invoke(cli, ["publish", "good-agent"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            mock_pub.assert_called_once()
+            call_manifest, call_zip = mock_pub.call_args.args
+            self.assertEqual(call_manifest["name"], "good-agent")
+            self.assertEqual(call_manifest["description"], "A test agent")
+            self.assertIn(REGISTRY_URL, result.output)
+            self.assertIn("good-agent@1.0.0", result.output)
+
+    def test_publish_version_override(self):
+        """--version flag overrides the manifest version in the ZIP name lookup and upload."""
+        with self.runner.isolated_filesystem():
+            _setup_agent(self.runner, "ver-agent")
+            self.runner.invoke(cli, ["wrap", "ver-agent", "--out", "."])
+            # Rename ZIP to match the overridden version
+            os.rename("ver-agent-v1.0.0.zip", "ver-agent-v2.0.0.zip")
+
+            with patch("agent_gen.cli._registry_publish", return_value={}) as mock_pub:
+                result = self.runner.invoke(cli, ["publish", "ver-agent", "--version", "2.0.0"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            call_manifest, _ = mock_pub.call_args.args
+            self.assertEqual(call_manifest["version"], "2.0.0")
+
+    def test_publish_tags(self):
+        """--tag options are forwarded to the registry manifest payload."""
+        with self.runner.isolated_filesystem():
+            _setup_agent(self.runner, "tagged-agent")
+            self.runner.invoke(cli, ["wrap", "tagged-agent"])
+
+            with patch("agent_gen.cli._registry_publish", return_value={}) as mock_pub:
+                result = self.runner.invoke(
+                    cli, ["publish", "tagged-agent", "--tag", "nlp", "--tag", "retrieval"]
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            call_manifest, _ = mock_pub.call_args.args
+            self.assertEqual(call_manifest["tags"], ["nlp", "retrieval"])
+
+    def test_publish_quiet_suppresses_output(self):
+        """publish in --quiet mode should produce no output on success."""
+        with self.runner.isolated_filesystem():
+            _setup_agent(self.runner, "quiet-agent")
+            self.runner.invoke(cli, ["wrap", "quiet-agent"])
+
+            with patch("agent_gen.cli._registry_publish", return_value={}):
+                result = self.runner.invoke(cli, ["--quiet", "publish", "quiet-agent"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(result.output.strip(), "")
+
+
+class TestImportFromRegistry(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def _make_registry_zip(self, name: str, version: str = "1.0.0") -> bytes:
+        """Build a minimal valid agent ZIP in memory."""
+        manifest = {
+            "name": name,
+            "version": version,
+            "description": "Registry agent",
+            "resources": {"skills": [], "commands": [], "docs": [], "scripts": [], "orchestration": []},
+        }
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(MANIFEST_FILE, json.dumps(manifest))
+        return buf.getvalue()
+
+    def test_import_from_registry_mocked(self):
+        """import --from-registry should download ZIP, unpack, and register the agent."""
+        zip_bytes = self._make_registry_zip("reg-agent")
+        entry = {
+            "name": "reg-agent",
+            "version": "1.0.0",
+            "zip_url": "https://agentfactory.dev/files/reg-agent-v1.0.0.zip",
+        }
+
+        with self.runner.isolated_filesystem():
+            with patch("agent_gen.cli._registry_fetch", return_value=(entry, zip_bytes)) as mock_fetch:
+                result = self.runner.invoke(cli, ["import", "--from-registry", "reg-agent"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            mock_fetch.assert_called_once_with("reg-agent")
+            self.assertTrue(os.path.exists(f"{AGENTS}/reg-agent/{MANIFEST_FILE}"))
+
+    def test_import_from_registry_versioned_slug(self):
+        """import --from-registry my-agent@1.2.0 passes the full slug to _registry_fetch."""
+        zip_bytes = self._make_registry_zip("pinned-agent", "1.2.0")
+        entry = {
+            "name": "pinned-agent",
+            "version": "1.2.0",
+            "zip_url": "https://agentfactory.dev/files/pinned-agent-v1.2.0.zip",
+        }
+
+        with self.runner.isolated_filesystem():
+            with patch("agent_gen.cli._registry_fetch", return_value=(entry, zip_bytes)) as mock_fetch:
+                result = self.runner.invoke(cli, ["import", "--from-registry", "pinned-agent@1.2.0"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            mock_fetch.assert_called_once_with("pinned-agent@1.2.0")
+
+    def test_import_mutual_exclusion(self):
+        """Mixing --from-registry and --from-git should be rejected."""
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(
+                cli, ["import", "--from-registry", "some-agent", "--from-git", "https://example.com/agent.git"]
+            )
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("mutually exclusive", result.output)
+
+    def test_import_no_source_fails(self):
+        """import with no source should print a usage error."""
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(cli, ["import"])
+            self.assertNotEqual(result.exit_code, 0)
+
+    def test_import_from_registry_quiet(self):
+        """import --from-registry in --quiet mode should produce no output."""
+        zip_bytes = self._make_registry_zip("quiet-reg-agent")
+        entry = {
+            "name": "quiet-reg-agent",
+            "version": "1.0.0",
+            "zip_url": "https://agentfactory.dev/files/quiet-reg-agent-v1.0.0.zip",
+        }
+
+        with self.runner.isolated_filesystem():
+            with patch("agent_gen.cli._registry_fetch", return_value=(entry, zip_bytes)):
+                result = self.runner.invoke(cli, ["--quiet", "import", "--from-registry", "quiet-reg-agent"])
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(result.output.strip(), "")


### PR DESCRIPTION
## Summary

- Adds `agentfactory-gen publish <name>` — uploads a wrapped Portable Unit (`.zip`) to the public registry via multipart POST
- Adds `import --from-registry SLUG` option — fetches and installs an agent by slug (supports `name@version` pinning)
- Zero new dependencies: all HTTP via stdlib `urllib.request`; auth via optional `~/.agentfactory/token`

## Changes

- `src/agent_gen/cli.py`: `REGISTRY_URL` constant, `_registry_publish()`, `_registry_fetch()`, `_attach_auth_header()` helpers; `publish` command; `--from-registry` option on `import`
- `src/tests/test_registry.py`: 11 tests covering all publish and import-from-registry paths
- `docs/FEATURE-REGISTRY-CLI.md`: full feature documentation — architecture, 3 flow diagrams, 8 scenario diagrams, troubleshooting table

## Test plan

- [ ] `pytest src/tests/test_registry.py` — all 11 tests pass
- [ ] `pytest` — full suite passes
- [ ] `ruff check src/` — no lint errors
- [ ] Review box-drawing diagrams in `docs/FEATURE-REGISTRY-CLI.md` render correctly

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)