### PR TITLE
feat(cli): export — patch a local agent back to its source-of-truth repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 <!-- version: 2.8.0 -->
 
+## [Unreleased]
+
+### Added
+- **`agentfactory-gen export <name>`** — patch a locally-modified agent back to its
+  source-of-truth git repo (the inverse of `import`). Clones the source, applies this
+  project's `.ai/agents/<name>/` over the agent's location (auto-detected `agent/`
+  subpath or repo root), commits on `agentfactory/export-<name>`, pushes, and opens a PR.
+  - `--git URL` (default: the source recorded at import) · `--subpath` · `--branch` ·
+    `-m/--message` · `--no-push` (writes a `.patch`) · `--no-pr`.
+  - `import` now records the source (`{"git": url}` / `{"registry": slug}`) in the agent
+    manifest so `export` defaults to it.
+  - `--git` accepts local paths / `file://` (offline + testable).
+
 ## [v2.8.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ agentfactory-gen wrap <name> --out <dir>     # write ZIP to a specific directory
 agentfactory-gen import <zip>                # unpack ZIP and register agent
 agentfactory-gen import --from-git <url>     # clone repo, auto-retrofit, and import
 agentfactory-gen import --from-registry <slug>  # download and install from public registry
+agentfactory-gen export <name>               # patch a locally-edited agent back to its source repo (branch + PR)
+agentfactory-gen export <name> --git <url>   # … to an explicit source; --no-push writes a .patch
 agentfactory-gen publish <name>              # upload wrapped agent to public registry
 agentfactory-gen publish <name> --version <v> --tag <t>  # override version and add tags
 agentfactory-gen uninstall <name>            # remove agent cleanly

--- a/docs/FEATURE-EXPORT-CLI.md
+++ b/docs/FEATURE-EXPORT-CLI.md
@@ -1,0 +1,243 @@
+# Export — patch a local agent back to its source repo
+<!-- version: 1.0.0 -->
+
+PR: #180 · Command: `agentfactory-gen export`
+
+The inverse of `import`: take an agent you edited locally under
+`.ai/agents/<name>/` and flow those changes **back upstream** to the agent's
+source-of-truth git repo as a reviewable branch + PR.
+
+---
+
+## 1. Overview
+
+```
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  PROBLEM                                                              │
+  │    `import` is one-way. You import an agent, improve its SKILL.md /   │
+  │    scripts in your project, and the upstream repo never sees it.      │
+  │                                                                       │
+  │  SOLUTION                                                             │
+  │    `export <name>` clones the source, applies your local agent over  │
+  │    it, commits on a branch, pushes, and opens a PR — a round trip.    │
+  └──────────────────────────────────────────────────────────────────────┘
+```
+
+`import` records where an agent came from; `export` reads that and patches the
+changes back. The source is never force-pushed — every export is an isolated
+branch (`agentfactory/export-<name>`) and a PR, so a human reviews the merge.
+
+---
+
+## 2. The round trip
+
+```
+        agentfactory-gen import                 agentfactory-gen export
+   ┌────────────────────────────┐          ┌────────────────────────────┐
+   │  source repo (git)         │          │  .ai/agents/<name>/        │
+   │    agent/ …                │          │    (your local edits)      │
+   └─────────────┬──────────────┘          └─────────────┬──────────────┘
+                 │  clone + register                     │  clone source
+                 ▼                                        ▼
+   ┌────────────────────────────┐          ┌────────────────────────────┐
+   │  .ai/agents/<name>/        │          │  apply over agent/ subpath │
+   │  + manifest.source = {git} │ ───────► │  branch agentfactory/      │
+   │                            │  edit    │     export-<name>          │
+   │                            │          │  commit · push · PR        │
+   └────────────────────────────┘          └─────────────┬──────────────┘
+                                                          ▼
+                                              ┌────────────────────────────┐
+                                              │  source repo: new PR       │
+                                              │  (human reviews + merges)  │
+                                              └────────────────────────────┘
+```
+
+---
+
+## 3. Synopsis
+
+```
+  agentfactory-gen export <NAME> [options]
+
+  ┌─ option ─────────────┬─ default ──────────────────┬─ purpose ───────────────────────┐
+  │ --git URL            │ manifest.source.git        │ source repo to patch back to     │
+  │ --subpath PATH       │ auto-detect (agent/ | root)│ where the agent lives upstream   │
+  │ --branch NAME        │ agentfactory/export-<name> │ branch to create + push          │
+  │ -m, --message TEXT   │ "agent(<name>): sync …"     │ commit message                   │
+  │ --project-root PATH  │ .                          │ project holding the agent        │
+  │ --push / --no-push   │ --push                     │ push branch (else write a .patch)│
+  │ --pr / --no-pr       │ --pr                       │ open a PR via `gh` after push    │
+  └──────────────────────┴────────────────────────────┴──────────────────────────────────┘
+```
+
+---
+
+## 4. Execution flow (happy path)
+
+```
+  export <name>
+     │
+     ├─ 1. locate agent .......... .ai/agents/<name>/        (error if missing)
+     ├─ 2. resolve source ........ --git ▸ manifest.source.git (error if neither)
+     ├─ 3. normalize URL ......... https/git@/ssh/git:///file:// or local path
+     ├─ 4. git clone source ...... temp dir                  (error on clone fail)
+     ├─ 5. detect subpath ........ agent/manifest? → "agent" ; root manifest? → "" ; else "agent"
+     ├─ 6. apply local agent ..... copy manifest + skills/commands/docs/scripts/orchestration
+     ├─ 7. branch + add .......... git checkout -b <branch> ; git add -A
+     ├─ 8. changed? ─ no ───────── "No changes to export ✓"  (exit 0, nothing pushed)
+     │              └ yes
+     ├─ 9. commit ................ as AgentFactory <agentfactory@local>
+     ├─ 10. push ................. git push -u origin <branch>   (skipped with --no-push)
+     └─ 11. PR ................... gh pr create                 (skipped with --no-pr)
+```
+
+---
+
+## 5. Concrete examples
+
+### 5.1 Happy path — recorded source, push + PR
+```
+  $ agentfactory-gen export docs-system
+  [librarian] Cloning https://github.com/me/docs-system ...
+  [librarian] Applying 'docs-system' → agent ...
+  [librarian] Committed: 9f2c1ab agent(docs-system): sync from AgentFactory export
+  [librarian] Pushing 'agentfactory/export-docs-system' to origin ...
+  [librarian] PR opened: https://github.com/me/docs-system/pull/42
+```
+
+### 5.2 No recorded source — pass it explicitly
+```
+  $ agentfactory-gen export demo --git git@github.com:me/demo.git
+```
+
+### 5.3 Offline / no push — produce a patch you apply by hand
+```
+  $ agentfactory-gen export demo --no-push
+  [librarian] Committed: 1a2b3c4 agent(demo): sync from AgentFactory export
+  [librarian] --no-push: patch written to demo-export.patch
+    apply upstream with:  git checkout -b agentfactory/export-demo && git am demo-export.patch
+```
+
+### 5.4 Push a branch but open the PR yourself
+```
+  $ agentfactory-gen export demo --no-pr
+  [librarian] Pushed 'agentfactory/export-demo'. Open a PR from it when ready.
+```
+
+### 5.5 Nothing changed since last sync
+```
+  $ agentfactory-gen export demo
+  [librarian] No changes to export — the source already matches. ✓
+```
+
+---
+
+## 6. What gets applied (and what does not)
+
+```
+  COPIED over the source's agent location:
+    ✔ agent-manifest.json
+    ✔ skills/        ✔ commands/     ✔ docs/
+    ✔ scripts/       ✔ orchestration/        (the TRACKED_DIRS)
+
+  NOT touched:
+    ✗ files in the source outside the agent location (READMEs, CI, etc.)
+    ✗ the source's default branch (export only writes a feature branch)
+    ✗ git history of the source (no force-push, no rewrite)
+```
+
+> A tracked directory present locally **replaces** its upstream counterpart
+> (`rmtree` + `copytree`) so deletions propagate. Files the local agent does not
+> have in a tracked dir are removed on the branch — intended, since the local
+> agent is the source of the patch.
+
+---
+
+## 7. Behaviour & decisions
+
+```
+  ┌─ DECISION ───────────────────┬─ WHY ───────────────────────────────────────┐
+  │ Branch + PR, never main      │ exports are proposals; a human merges        │
+  │ Source recorded at import    │ no need to retype the URL; round-trip by name│
+  │ Auto-detect agent/ subpath   │ matches how bundles are laid out (agent/…)   │
+  │ --git accepts file:// + path │ offline use + deterministic tests            │
+  │ No-op is success (exit 0)    │ safe to run in scripts / pre-commit          │
+  │ Commit identity = AgentFactory│ traceable, never impersonates the operator  │
+  └──────────────────────────────┴──────────────────────────────────────────────┘
+```
+
+---
+
+## 8. Validation, errors & recovery
+
+```
+  ┌─ situation ───────────────────┬─ message ─────────────────────────┬─ recovery ─────────────────┐
+  │ agent dir missing             │ "Agent '<n>' not found at …"       │ check --project-root / name │
+  │ no source + no --git          │ "No source repo recorded for …"    │ pass --git URL              │
+  │ bad URL / unreachable         │ "git clone failed: …"              │ fix URL / auth / network    │
+  │ --subpath contains '..'       │ "must not contain '..'"            │ use a path inside the repo  │
+  │ subpath escapes repo          │ "resolves outside … traversal"     │ correct --subpath           │
+  │ push rejected (no write/auth) │ "git push failed: …"               │ get write access; or --no-push│
+  │ gh missing / PR fails         │ "Pushed …; open a PR manually"     │ branch IS pushed; open PR by hand│
+  └───────────────────────────────┴────────────────────────────────────┴─────────────────────────────┘
+```
+
+Recovery principles:
+- **Idempotent & isolated** — re-running re-clones a fresh temp dir; nothing is
+  left dirty in your project (temp dir is always removed in a `finally`).
+- **Push failure ≠ data loss** — fall back to `--no-push` to get a `.patch`.
+- **PR failure ≠ work lost** — the branch is already on the remote; open the PR
+  in the GitHub UI from the printed branch name.
+
+---
+
+## 9. What changed in this implementation
+
+### 9.1 File layout — before vs after
+```
+  BEFORE                                  AFTER
+  src/agent_gen/                          src/agent_gen/
+  └── cli.py                              └── cli.py
+       ├── import  (one-way in)                ├── import  (now records source)
+       ├── wrap                                ├── wrap
+       └── publish                             ├── publish
+                                               └── export  ← NEW (one-way out)
+  src/tests/                              src/tests/
+  └── test_cli.py …                       ├── test_cli.py …
+                                          └── test_export.py  ← NEW (5 tests)
+```
+
+### 9.2 Manifest — before vs after import
+```
+  BEFORE (imported agent)                 AFTER (imported agent)
+  {                                       {
+    "name": "demo",                         "name": "demo",
+    "version": "1.0.0",                      "version": "1.0.0",
+    "resources": { … }                       "resources": { … },
+  }                                          "source": { "git": "https://…/demo" }  ← NEW
+                                          }
+```
+
+### 9.3 Behaviour — before vs after
+```
+  ACTION: "I improved an imported agent's SKILL.md"
+
+  BEFORE                                   AFTER
+  ──────                                   ─────
+  edit .ai/agents/demo/…                   edit .ai/agents/demo/…
+  ▸ no path back upstream                  ▸ agentfactory-gen export demo
+  ▸ copy/paste into the source repo        ▸ → branch + PR on the source repo
+    by hand, hope nothing drifts             → reviewed + merged upstream
+```
+
+Ownership boundary: the **operator** owns local edits; **export** owns the
+mechanical clone→apply→branch→push; the **upstream maintainer** owns the merge.
+Export never crosses that last boundary (no direct push to the default branch).
+
+---
+
+## 10. See also
+
+- E2E test guide: `docs/TESTING-EXPORT-CLI-E2E.md`
+- Design analysis, gaps, infra alignment: `docs/reviews/REVIEW-EXPORT-CLI.md`
+- Related upstream gaps: AgentFactory#179 (import fidelity)

--- a/docs/TESTING-EXPORT-CLI-E2E.md
+++ b/docs/TESTING-EXPORT-CLI-E2E.md
@@ -1,0 +1,161 @@
+# End-to-End Test Guide — `agentfactory-gen export`
+<!-- version: 1.0.0 -->
+
+PR: #180 · Pairs with `docs/FEATURE-EXPORT-CLI.md`
+
+How to validate the `export` command end-to-end by hand: preconditions, steps,
+expected output, validation checks, and failure indicators. Uses a **local bare
+repo** as the "remote" so no GitHub access is required.
+
+---
+
+## Preconditions
+
+```
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ 1. git ≥ 2.x on PATH                  git --version                       │
+  │ 2. Python ≥ 3.10                      python3 --version                   │
+  │ 3. The CLI (this branch), either:                                         │
+  │      pip install -e .                 → `agentfactory-gen`                 │
+  │      or run from source:             PYTHONPATH=src python3 -m agent_gen.cli│
+  │ 4. (only for real --pr) gh installed + authenticated:  gh auth status     │
+  │ 5. Unit tests green:                 PYTHONPATH=src pytest src/tests/test_export.py -q │
+  └──────────────────────────────────────────────────────────────────────────┘
+```
+
+> The examples below use `RUN` as a stand-in for the CLI:
+> `RUN(){ PYTHONPATH=src python3 -m agent_gen.cli "$@"; }` (run from the repo root).
+
+---
+
+## T0 — Build the fixture (a fake "remote" + a local agent)
+
+```bash
+T=$(mktemp -d)
+# source repo with the agent at agent/
+mkdir -p "$T/source/agent/skills"
+cd "$T/source" && git init -q && git config user.email a@a && git config user.name a
+echo '{"name":"demo","version":"1.0.0","resources":{}}' > agent/agent-manifest.json
+echo 'OLD skill' > agent/skills/do.md
+git add -A && git commit -qm init
+# bare clone = the pushable remote
+git clone -q --bare "$T/source" "$T/remote.git"
+# a project with an imported + EDITED agent (source recorded)
+mkdir -p "$T/proj/.ai/agents/demo/skills"
+printf '{"name":"demo","version":"1.1.0","resources":{},"source":{"git":"file://%s"}}' "$T/remote.git" \
+  > "$T/proj/.ai/agents/demo/agent-manifest.json"
+echo 'NEW improved skill' > "$T/proj/.ai/agents/demo/skills/do.md"
+echo 'brand new file'      > "$T/proj/.ai/agents/demo/skills/extra.md"
+```
+
+**Expected:** no errors; `$T/remote.git` exists; `$T/proj/.ai/agents/demo/` has the edited files.
+
+---
+
+## T1 — Happy path: export to the recorded source (push, no PR)
+
+| | |
+|---|---|
+| **Steps** | `RUN export demo --project-root "$T/proj" --no-pr` |
+| **Expected** | `Cloning file://…/remote.git` → `Applying 'demo' → agent` → `Committed: <sha> agent(demo): sync …` → `Pushed 'agentfactory/export-demo'.` |
+| **Validate** | `git --git-dir="$T/remote.git" branch` lists `agentfactory/export-demo` |
+| **Validate** | clone the branch and check content: |
+
+```bash
+git clone -q "$T/remote.git" "$T/v" -b agentfactory/export-demo
+grep -q 'NEW improved skill' "$T/v/agent/skills/do.md"   && echo OK-modified
+test -f "$T/v/agent/skills/extra.md"                      && echo OK-added
+python3 -c "import json;assert json.load(open('$T/v/agent/agent-manifest.json'))['version']=='1.1.0'" && echo OK-manifest
+```
+**Expected:** `OK-modified`, `OK-added`, `OK-manifest`.
+
+---
+
+## T2 — Explicit `--git` overrides / no recorded source
+
+| | |
+|---|---|
+| **Steps** | strip `source` from the manifest, then `RUN export demo --git "file://$T/remote.git" --branch t/explicit --project-root "$T/proj" --no-pr` |
+| **Expected** | exit 0; branch `t/explicit` lands in the remote with the same content |
+
+---
+
+## T3 — `--no-push` writes a patch (offline)
+
+| | |
+|---|---|
+| **Steps** | `RUN export demo --project-root "$T/proj" --no-push` |
+| **Expected** | `--no-push: patch written to demo-export.patch` |
+| **Validate** | `test -s "$T/proj/demo-export.patch" && head -1 "$T/proj/demo-export.patch"` → a `From <sha>` git-format-patch header |
+
+---
+
+## T4 — No-op when source already matches
+
+| | |
+|---|---|
+| **Pre** | merge/ff the export branch into the remote's default branch (so it matches local), or re-export onto a branch already containing the changes |
+| **Steps** | `RUN export demo --project-root "$T/proj" --no-pr` |
+| **Expected** | `No changes to export — the source already matches. ✓` and **exit 0** (nothing pushed) |
+
+---
+
+## T5 — Error & edge cases
+
+```
+  ┌─ case ───────────────────────┬─ command ───────────────────────────────┬─ expected ─────────────┐
+  │ missing agent                │ RUN export ghost --project-root "$T/proj"│ exit≠0 "not found"      │
+  │ no source + no --git         │ (source stripped) RUN export demo …      │ exit≠0 "No source repo" │
+  │ bad URL                      │ RUN export demo --git https://nope.invalid/x.git │ exit≠0 "git clone failed"│
+  │ path traversal               │ RUN export demo --subpath ../etc …       │ exit≠0 "must not contain '..'"│
+  │ local path as --git          │ RUN export demo --git "$T/source" …      │ accepted (→ file:// URL)│
+  └──────────────────────────────┴──────────────────────────────────────────┴─────────────────────────┘
+```
+
+---
+
+## Validation checks (summary)
+
+```
+  ✔ exit code 0 on success, non-zero on every error path
+  ✔ branch agentfactory/export-<name> created on the remote (T1)
+  ✔ modified + added + deleted files all reflected on the branch (T1)
+  ✔ source default branch UNCHANGED (export never touches it)
+  ✔ project working tree UNCHANGED — temp clone removed (ls "$T/proj"; no stray dirs)
+  ✔ --no-push yields an appliable patch (T3)
+  ✔ no-op path is exit 0, no push (T4)
+  ✔ commit author = AgentFactory <agentfactory@local> (git log on the branch)
+```
+
+---
+
+## Common failure indicators
+
+```
+  ┌─ symptom ────────────────────────────┬─ likely cause ───────────────────────────────┐
+  │ "No such command 'export'"           │ running pip-installed old build, not this src │
+  │                                      │   → use PYTHONPATH=src python3 -m agent_gen.cli│
+  │ clone fails on file://               │ bare repo path wrong / not created (redo T0)  │
+  │ push "denied"/"read-only"            │ remote not writable (use bare repo, or --no-push)│
+  │ PR step errors but branch present    │ gh missing/unauth — open PR manually (expected)│
+  │ deletions not propagated             │ check the local agent actually omits the file │
+  │ stray temp dir after a crash         │ /tmp/agentfactory_export_* — safe to delete   │
+  └──────────────────────────────────────┴───────────────────────────────────────────────┘
+```
+
+---
+
+## Confirming the implementation is correct
+
+```
+  1. PYTHONPATH=src pytest src/tests/test_export.py -q          → 5 passed
+  2. PYTHONPATH=src pytest src/tests -q                          → only the 2 pre-existing
+                                                                   live gemini/codex auth
+                                                                   tests fail (unrelated)
+  3. T1 round-trips a real edit onto a branch with correct content
+  4. T5 produces the exact error strings + non-zero exit for every bad input
+  5. After all runs: `git -C "$T/proj" status` (if a repo) and `ls "$T/proj"`
+     show no stray files beyond the optional demo-export.patch
+```
+
+Cleanup: `rm -rf "$T"`.

--- a/docs/reviews/REVIEW-EXPORT-CLI.md
+++ b/docs/reviews/REVIEW-EXPORT-CLI.md
@@ -1,0 +1,239 @@
+# Review — `agentfactory-gen export` (design, gaps, infra, doc tracking)
+<!-- version: 1.0.0 -->
+
+PR: #180 · Consolidated analysis of the `export` command and its surrounding
+processes. Pairs with `docs/FEATURE-EXPORT-CLI.md` and
+`docs/TESTING-EXPORT-CLI-E2E.md`.
+
+> **Scope note (honesty first).** `export` is a **CLI command** in
+> `src/agent_gen/cli.py`. It does not introduce services, routes, an operator
+> console, or deployment logic. Sections on infrastructure and "operator
+> console / route-separated workflow" are included as **explicit alignment
+> checks** and are marked **N/A with reasoning** where they do not apply, rather
+> than fabricated.
+
+---
+
+## 1. Design reasoning & trade-offs
+
+```
+  ┌─ decision ───────────────────┬─ alternatives ───────────────┬─ why this one ─────────────────┐
+  │ branch + PR (never main)     │ direct push to main          │ exports are proposals; keeps a │
+  │                              │                              │ human in the merge loop        │
+  │ record source at import      │ ask for --git every time     │ round-trip by name; one source │
+  │                              │                              │ of truth on disk               │
+  │ copy whole TRACKED_DIRS      │ 3-way merge / per-file diff  │ simple, predictable; the local │
+  │ (replace upstream agent dir) │                              │ agent IS the patch             │
+  │ auto-detect agent/ subpath   │ require --subpath always     │ matches bundle layout; override│
+  │                              │                              │ stays available                │
+  │ accept file:// + local path  │ URL-only (like import)       │ offline + deterministic tests; │
+  │                              │                              │ also nudges #179 gap 2         │
+  │ reuse subprocess git         │ GitPython dependency         │ zero new deps; mirrors existing│
+  │                              │                              │ _clone_and_prepare style       │
+  └──────────────────────────────┴───────────────────────────────┴────────────────────────────────┘
+```
+
+Primary trade-off: **whole-directory replace** is intentionally dumb. It cannot
+do a semantic merge, but it is predictable and review-gated — the PR diff shows
+exactly what changes, and a maintainer resolves conflicts in the source repo.
+
+---
+
+## 2. Assumptions made by the implementation
+
+```
+  A1  The local agent dir is the authoritative version of the patch.
+  A2  The agent lives at agent/ (or repo root) in the source — auto-detected,
+      override with --subpath.
+  A3  `origin` of the freshly cloned source is the correct push target
+      (no fork/upstream split handled yet).
+  A4  Tracked content = TRACKED_DIRS + agent-manifest.json. Files outside those
+      (e.g. a source-side README) are out of scope and untouched.
+  A5  The operator has push rights to the source (or will use --no-push).
+  A6  `gh` is configured when --pr is used; absence is non-fatal (branch pushed).
+  A7  git identity is supplied per-commit (AgentFactory) so no global config is needed.
+```
+
+---
+
+## 3. Identified gaps & risks
+
+```
+  ┌─ id ─┬─ gap / risk ──────────────────────────────────┬─ severity ─┬─ mitigation today ───────────┐
+  │ G1   │ no fork workflow (always pushes to origin)     │ medium     │ --no-push patch; or clone a  │
+  │      │                                                │            │ fork and pass --git <fork>   │
+  │ G2   │ whole-dir replace deletes upstream-only files  │ medium     │ documented (§6 feature doc); │
+  │      │ inside a tracked dir                           │            │ PR diff makes it visible     │
+  │ G3   │ branch reuse: re-export to an existing remote  │ low        │ pass a unique --branch       │
+  │      │ branch may need a force/--no-ff                │            │                              │
+  │ G4   │ no signature/provenance on the export commit   │ low        │ commit author is fixed+clear │
+  │ G5   │ source recorded only for --from-git/-registry, │ low        │ pass --git explicitly        │
+  │      │ not for ZIP/deploy imports                     │            │                              │
+  │ G6   │ secrets in a tracked dir would be exported     │ medium     │ operator responsibility; see │
+  │      │ verbatim                                       │            │ §8 safeguard S3             │
+  └──────┴────────────────────────────────────────────────┴────────────┴──────────────────────────────┘
+```
+
+---
+
+## 4. Missing scenarios (not yet covered)
+
+```
+  ✗ Fork-and-PR (push to a fork, PR to upstream) — only same-origin today.
+  ✗ Conflict/divergence detection (source moved since import) — relies on PR review.
+  ✗ Dry-run preview of the diff before cloning/pushing (`--dry-run`).
+  ✗ Multi-agent export in one invocation (`export --all`).
+  ✗ Selective export (only skills/, only one file).
+  ✗ Provenance: stamping the export with the local git_ref it was based on.
+```
+
+---
+
+## 5. Potential enhancements
+
+```
+  SHORT TERM
+    · --dry-run  → show the would-be diff + target branch, write nothing
+    · --fork     → push to a fork remote, open PR against upstream
+    · stamp manifest.source.exported_from = <local git_ref> for provenance
+    · --include / --exclude globs for selective export
+
+  LONG TERM
+    · 3-way merge against the source's recorded import ref (true sync, not replace)
+    · round-trip status: `agentfactory-gen status` showing local-vs-source drift
+    · registry-side export (publish a new version) symmetric with --from-registry
+    · signed export commits / attestation
+```
+
+---
+
+## 6. Additional checks & safeguards to add
+
+```
+  ┌─ id ─┬─ safeguard ──────────────────────────────────────────────┬─ status ──────┐
+  │ S1   │ confirm-before-push prompt (or --yes) for interactive use │ proposed      │
+  │ S2   │ refuse to export if the source default branch == target   │ proposed      │
+  │      │ branch (avoid accidental main writes)                     │               │
+  │ S3   │ secret scan of TRACKED_DIRS before commit (warn/block)    │ proposed      │
+  │ S4   │ size guard — refuse absurdly large agent dirs             │ proposed      │
+  │ S5   │ path-traversal guard on --subpath                         │ ✅ implemented│
+  │ S6   │ temp dir always cleaned (finally)                         │ ✅ implemented│
+  │ S7   │ URL scheme allow-list                                     │ ✅ implemented│
+  └──────┴───────────────────────────────────────────────────────────┴───────────────┘
+```
+
+---
+
+## 7. Documentation tracking & review process
+
+Verification that the docs for this feature are complete and current.
+
+```
+  ┌─ artifact ───────────────────────────────────┬─ state ──────────────────────────┐
+  │ Feature doc  docs/FEATURE-EXPORT-CLI.md       │ ✅ added (this PR)               │
+  │ E2E test     docs/TESTING-EXPORT-CLI-E2E.md   │ ✅ added (this PR)               │
+  │ Review       docs/reviews/REVIEW-EXPORT-CLI.md│ ✅ this document                 │
+  │ CHANGELOG.md  [Unreleased] → Added: export     │ ✅ updated                       │
+  │ CLI --help    export + options                 │ ✅ generated from Click          │
+  │ Tests         src/tests/test_export.py (5)     │ ✅ added, passing                │
+  │ README.md     command list                     │ ◻ optional — add export to the   │
+  │                                               │   command table when merged      │
+  └───────────────────────────────────────────────┴──────────────────────────────────┘
+```
+
+**Architecture / workflow diagrams:** the round-trip, execution flow, and
+control-flow/ownership boundaries are diagrammed in
+`docs/FEATURE-EXPORT-CLI.md` §2/§4/§9 (box-drawing, terminal-safe).
+
+**Design & decision record:** §1 (trade-offs) + §2 (assumptions) of this doc.
+
+**"Operator Console Route-Separated Workflow System":** **N/A.** This repo has
+no operator console and no route-separated workflow surface. The CLI is invoked
+directly (`agentfactory-gen export`); there is no HTTP route, dispatcher, or
+console mediating it. If/when the registry API (`agent_gen.api`) grows an export
+endpoint, this section should be revisited.
+
+---
+
+## 8. Infrastructure configuration alignment
+
+Honest audit of the ops/infra checklist against the actual repo.
+
+```
+  WHAT EXISTS
+    docker-compose.yml   services: api (uvicorn agent_gen.api.main:app) + db (postgres:16)
+    Dockerfile.api       builds the registry API image
+    api/openapi.json     registry API spec
+    Ansible              none in this repo
+    operator console     none
+    routes               none (FastAPI app is the registry; no per-route workflow system)
+```
+
+```
+  ┌─ checklist item ─────────────────────────┬─ verdict ───────────────────────────────────┐
+  │ Docker Compose: services updated          │ NO CHANGE NEEDED — export is a CLI command;  │
+  │                                           │ it adds no service, port, or dependency.     │
+  │ Compose: env vars                         │ NO CHANGE — export reads no env; uses git/gh │
+  │                                           │ already available to the operator.           │
+  │ Compose: networks/volumes/deps            │ NO CHANGE — unaffected.                      │
+  │ Ansible playbooks/roles/inventory/secrets │ N/A — repo has no Ansible.                   │
+  │ Drift (code ↔ infra)                      │ NONE introduced — export does not touch the  │
+  │                                           │ api service or its image.                    │
+  │ Obsolete services/tasks/vars              │ NONE — nothing removed or deprecated.        │
+  │ Missing infra updates for this feature    │ NONE — feature is infra-neutral by design.   │
+  └───────────────────────────────────────────┴───────────────────────────────────────────────┘
+```
+
+**Validation steps used to confirm correctness**
+```
+  1. git diff --stat origin/main..HEAD   → only src/agent_gen/cli.py, src/tests/test_export.py,
+                                            CHANGELOG.md, docs/* changed (no compose/Dockerfile/api)
+  2. grep -rn "export" docker-compose.yml api/  → no coupling
+  3. docker compose config (lint)        → unchanged file still valid
+```
+
+**How configuration changes are tracked & reviewed**
+```
+  · Infra files live beside code in the same repo → reviewed in the same PR.
+  · CHANGELOG [Unreleased] records user-facing changes.
+  · CI (docs/CICD-WORKFLOW.md) runs the test suite on the PR.
+```
+
+**How this is enforced in the PR process — checklist**
+```
+  PR CHECKLIST (export-class / infra-touching changes)
+    [ ] If a service/port/env/volume changed → docker-compose.yml updated
+    [ ] If the API surface changed          → api/openapi.json regenerated
+    [ ] CHANGELOG [Unreleased] entry added
+    [ ] Tests added/updated and green (minus known live-adapter tests)
+    [ ] Docs added/updated (feature + test + review)
+  FAILURE CONDITIONS (block merge)
+    ✗ a new env var used in code but absent from compose / .env.example
+    ✗ api route added but openapi.json stale
+    ✗ test suite regressions beyond the 2 known live gemini/codex auth tests
+```
+
+**Common mismatch scenarios & required fixes** (for future infra-touching PRs)
+```
+  mismatch: code reads AGENTFACTORY_X, compose doesn't define it
+    fix:    add it to docker-compose.yml `environment:` and .env.example
+  mismatch: api endpoint added, openapi.json not regenerated
+    fix:    regenerate api/openapi.json; commit alongside the route
+  mismatch: db schema change, no migration
+    fix:    add the migration; note in CHANGELOG
+  (export PR #180 triggers NONE of these — it is CLI-only.)
+```
+
+---
+
+## 9. Verdict
+
+```
+  ┌──────────────────────────────────────────────────────────────────────────┐
+  │ export is a focused, well-isolated, test-covered CLI addition that closes │
+  │ the import round trip. It is infra-neutral (no compose/api/ansible drift).│
+  │ Ship it; track the medium-severity gaps (fork workflow G1, dir-replace    │
+  │ deletes G2, secret exposure G6) and the proposed safeguards (S1–S4) as    │
+  │ follow-ups.                                                               │
+  └──────────────────────────────────────────────────────────────────────────┘
+```

--- a/src/agent_gen/cli.py
+++ b/src/agent_gen/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import click
 
-from .librarian import TRACKED_DIRS, HARNESS_ROOT, CONTEXT_FILE, Librarian, _FORMAT_REGISTRY
+from .librarian import TRACKED_DIRS, HARNESS_ROOT, MANIFEST_FILE, CONTEXT_FILE, Librarian, _FORMAT_REGISTRY
 
 REGISTRY_URL = os.environ.get("AGENTFACTORY_REGISTRY_URL", "https://agentfactory.dev")
 
@@ -112,6 +112,25 @@ def _assert_within_root(rel_path: str, root: Path) -> None:
         raise click.ClickException(
             f"Path '{rel_path}' resolves outside the agent root — possible path traversal."
         )
+
+
+def _normalize_git_url(url: str) -> str:
+    """
+    Accept a remote URL (https/http/git@/ssh/git:///file://) or a local path.
+
+    An existing local path is converted to an absolute ``file://`` URL so the same
+    code path works for remotes, local clones, and tests.
+    """
+    remote_schemes = ("https://", "http://", "git@", "ssh://", "git://", "file://")
+    if url.startswith(remote_schemes):
+        return url
+    p = Path(url).expanduser()
+    if p.exists():
+        return p.resolve().as_uri()
+    raise click.ClickException(
+        f"Invalid git target '{url}'. Use a URL "
+        f"({', '.join(remote_schemes)}) or an existing local path."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -821,6 +840,21 @@ def import_agent(zip_path: str, from_git: str, from_registry: str, project_root:
     _echo(f"[librarian] Registering '{name}' in project manifest...")
     Librarian.register_in_project(manifest, project_root)
 
+    # Record where this agent came from so `export` can patch changes back to it.
+    source_ref = None
+    if from_git:
+        source_ref = {"git": from_git}
+    elif from_registry:
+        source_ref = {"registry": from_registry}
+    if source_ref:
+        agent_manifest = target_root / MANIFEST_FILE
+        try:
+            data = json.loads(agent_manifest.read_text())
+            data["source"] = source_ref
+            agent_manifest.write_text(json.dumps(data, indent=2))
+        except (OSError, ValueError):
+            pass  # non-fatal: export can still take --git explicitly
+
     # Clean up temp dir from --from-git clone
     if _cleanup:
         _cleanup()
@@ -846,6 +880,154 @@ def import_agent(zip_path: str, from_git: str, from_registry: str, project_root:
         if claude_md:
             _echo(f"  Check {claude_md} for your new instructions.")
     _echo("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# export
+# ---------------------------------------------------------------------------
+
+@cli.command("export")
+@click.argument("name")
+@click.option(
+    "--git",
+    "git_url",
+    default=None,
+    metavar="URL",
+    help="Source repo to patch (default: the agent's recorded source from import).",
+)
+@click.option(
+    "--subpath",
+    default=None,
+    help="Path inside the source repo where the agent lives (default: auto-detect).",
+)
+@click.option(
+    "--branch",
+    "branch_name",
+    default=None,
+    help="Branch to create & push (default: agentfactory/export-<name>).",
+)
+@click.option("-m", "--message", "message", default=None, help="Commit message.")
+@click.option(
+    "--project-root", default=".", show_default=True, help="Project root holding the agent."
+)
+@click.option("--push/--no-push", default=True, help="Push the branch to the source remote.")
+@click.option("--pr/--no-pr", default=True, help="Open a PR with gh (requires --push).")
+def export_agent(name, git_url, subpath, branch_name, message, project_root, push, pr):
+    """
+    Patch a locally-modified agent back to its source-of-truth git repo.
+
+    Clones the source, copies this project's agents/<NAME>/ over the agent's
+    location in the source, commits on a new branch, pushes, and opens a PR —
+    so edits made to an imported agent flow back upstream.
+    """
+    project_path = Path(project_root).resolve()
+    agent_root = project_path / HARNESS_ROOT / "agents" / name
+    if not agent_root.is_dir():
+        raise click.ClickException(f"Agent '{name}' not found at {agent_root}.")
+
+    manifest_path = agent_root / MANIFEST_FILE
+    manifest = {}
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except ValueError:
+            manifest = {}
+
+    src = git_url or (manifest.get("source") or {}).get("git")
+    if not src:
+        raise click.ClickException(
+            f"No source repo recorded for '{name}'. Pass --git URL "
+            "(this agent was imported from a ZIP/registry or deployed locally)."
+        )
+    src = _normalize_git_url(src)
+
+    branch_name = branch_name or f"agentfactory/export-{name}"
+    message = message or f"agent({name}): sync from AgentFactory export"
+
+    if subpath and ".." in Path(subpath).parts:
+        raise click.ClickException(f"--subpath '{subpath}' must not contain '..'.")
+
+    tmp_dir = tempfile.mkdtemp(prefix="agentfactory_export_")
+    clone_dir = os.path.join(tmp_dir, "src")
+
+    def _git(*args, check=True):
+        proc = subprocess.run(
+            ["git", "-C", clone_dir, *args], capture_output=True, text=True
+        )
+        if check and proc.returncode != 0:
+            raise click.ClickException(f"git {' '.join(args)} failed:\n{proc.stderr.strip()}")
+        return proc
+
+    try:
+        _echo(f"[librarian] Cloning {src} ...")
+        clone = subprocess.run(
+            ["git", "clone", "--quiet", src, clone_dir], capture_output=True, text=True
+        )
+        if clone.returncode != 0:
+            raise click.ClickException(f"git clone failed:\n{clone.stderr.strip()}")
+        clone_path = Path(clone_dir)
+
+        # Detect where the agent lives in the source repo.
+        if subpath is None:
+            if (clone_path / "agent" / MANIFEST_FILE).exists():
+                subpath = "agent"
+            elif (clone_path / MANIFEST_FILE).exists():
+                subpath = ""
+            else:
+                subpath = "agent"
+        dest = clone_path / subpath if subpath else clone_path
+        _assert_within_root(subpath or ".", clone_path)
+        dest.mkdir(parents=True, exist_ok=True)
+
+        # Apply the local agent (manifest + tracked resource dirs) over the source.
+        _echo(f"[librarian] Applying '{name}' → {subpath or '<repo root>'} ...")
+        if manifest_path.exists():
+            shutil.copy2(manifest_path, dest / MANIFEST_FILE)
+        for d in TRACKED_DIRS:
+            src_d = agent_root / d
+            if src_d.is_dir():
+                dst_d = dest / d
+                if dst_d.exists():
+                    shutil.rmtree(dst_d)
+                shutil.copytree(src_d, dst_d)
+
+        _git("checkout", "-b", branch_name)
+        _git("add", "-A")
+        if not _git("status", "--porcelain").stdout.strip():
+            _echo("[librarian] No changes to export — the source already matches. ✓")
+            return
+        _git(
+            "-c", "user.email=agentfactory@local", "-c", "user.name=AgentFactory",
+            "commit", "-m", message,
+        )
+        _echo("[librarian] Committed: " + _git("--no-pager", "log", "-1", "--oneline").stdout.strip())
+
+        if not push:
+            patch_file = project_path / f"{name}-export.patch"
+            patch_file.write_text(_git("--no-pager", "format-patch", "-1", "--stdout").stdout)
+            _echo(f"[librarian] --no-push: patch written to {patch_file}")
+            _echo(f"  apply upstream with:  git checkout -b {branch_name} && git am {patch_file.name}")
+            return
+
+        _echo(f"[librarian] Pushing '{branch_name}' to origin ...")
+        _git("push", "-u", "origin", branch_name)
+
+        if pr:
+            pr_proc = subprocess.run(
+                ["gh", "pr", "create", "--head", branch_name, "--title", message,
+                 "--body", f"Automated export of agent `{name}` from AgentFactory."],
+                cwd=clone_dir, capture_output=True, text=True,
+            )
+            if pr_proc.returncode == 0:
+                _echo(f"[librarian] PR opened: {pr_proc.stdout.strip()}")
+            else:
+                _echo(f"[librarian] Pushed '{branch_name}'; open a PR manually "
+                      f"(gh: {pr_proc.stderr.strip()})", err=True)
+        else:
+            _echo(f"[librarian] Pushed '{branch_name}'. Open a PR from it when ready.")
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
 
 # ---------------------------------------------------------------------------
 # adapter

--- a/src/tests/test_export.py
+++ b/src/tests/test_export.py
@@ -1,0 +1,111 @@
+"""Tests for `agentfactory-gen export` — patch a local agent back to its source repo."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_gen.cli import cli
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+class TestExport(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.runner = CliRunner()
+
+        # 1. a source repo with the agent at agent/
+        self.source = self.root / "source"
+        (self.source / "agent" / "skills").mkdir(parents=True)
+        (self.source / "agent" / "agent-manifest.json").write_text(
+            json.dumps({"name": "demo", "version": "1.0.0", "resources": {}})
+        )
+        (self.source / "agent" / "skills" / "do.md").write_text("OLD\n")
+        _git(self.source, "init", "-q")
+        _git(self.source, "config", "user.email", "a@a")
+        _git(self.source, "config", "user.name", "a")
+        _git(self.source, "add", "-A")
+        _git(self.source, "commit", "-qm", "init")
+
+        # 2. a bare clone = the pushable "remote"
+        self.bare = self.root / "remote.git"
+        subprocess.run(
+            ["git", "clone", "-q", "--bare", str(self.source), str(self.bare)],
+            check=True, capture_output=True,
+        )
+        self.url = self.bare.as_uri()
+
+        # 3. a project holding a MODIFIED imported agent
+        self.proj = self.root / "proj"
+        (self.proj / ".ai" / "agents" / "demo" / "skills").mkdir(parents=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_agent(self, *, source=True):
+        agent = self.proj / ".ai" / "agents" / "demo"
+        manifest = {"name": "demo", "version": "1.1.0", "resources": {}}
+        if source:
+            manifest["source"] = {"git": self.url}
+        (agent / "agent-manifest.json").write_text(json.dumps(manifest))
+        (agent / "skills" / "do.md").write_text("NEW\n")
+        (agent / "skills" / "extra.md").write_text("added\n")
+
+    def _branch_tree(self, branch):
+        out = self.root / "verify"
+        subprocess.run(
+            ["git", "clone", "-q", str(self.bare), str(out), "-b", branch],
+            check=True, capture_output=True,
+        )
+        return out
+
+    def test_export_pushes_to_recorded_source(self):
+        self._write_agent(source=True)
+        res = self.runner.invoke(
+            cli, ["export", "demo", "--project-root", str(self.proj), "--no-pr"]
+        )
+        self.assertEqual(res.exit_code, 0, res.output)
+        tree = self._branch_tree("agentfactory/export-demo")
+        self.assertEqual((tree / "agent" / "skills" / "do.md").read_text(), "NEW\n")
+        self.assertTrue((tree / "agent" / "skills" / "extra.md").exists())
+        m = json.loads((tree / "agent" / "agent-manifest.json").read_text())
+        self.assertEqual(m["version"], "1.1.0")
+
+    def test_export_explicit_git_url_overrides(self):
+        self._write_agent(source=False)  # no recorded source
+        res = self.runner.invoke(
+            cli, ["export", "demo", "--project-root", str(self.proj),
+                  "--git", self.url, "--branch", "x/y", "--no-pr"]
+        )
+        self.assertEqual(res.exit_code, 0, res.output)
+        self.assertTrue((self._branch_tree("x/y") / "agent" / "skills" / "extra.md").exists())
+
+    def test_export_no_source_errors(self):
+        self._write_agent(source=False)
+        res = self.runner.invoke(cli, ["export", "demo", "--project-root", str(self.proj)])
+        self.assertNotEqual(res.exit_code, 0)
+        self.assertIn("No source repo", res.output)
+
+    def test_export_no_push_writes_patch(self):
+        self._write_agent(source=True)
+        res = self.runner.invoke(
+            cli, ["export", "demo", "--project-root", str(self.proj), "--no-push"]
+        )
+        self.assertEqual(res.exit_code, 0, res.output)
+        self.assertTrue((self.proj / "demo-export.patch").exists())
+
+    def test_export_missing_agent_errors(self):
+        res = self.runner.invoke(cli, ["export", "ghost", "--project-root", str(self.proj)])
+        self.assertNotEqual(res.exit_code, 0)
+        self.assertIn("not found", res.output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## `agentfactory-gen export` — patch a local agent back to its source repo

The inverse of `import`. When you've edited an imported agent in
`.ai/agents/<name>/`, `export` flows those changes back **upstream** to the
agent's source-of-truth repo as a reviewable PR.

```mermaid
flowchart LR
    A[".ai/agents/&lt;name&gt;/<br/>(local edits)"] --> E([agentfactory-gen export])
    E --> C[clone source repo]
    C --> P["apply over agent/ subpath<br/>(auto-detected)"]
    P --> B["branch agentfactory/export-&lt;name&gt;<br/>commit + push"]
    B --> R([gh pr create])
```

### What it does
1. Resolves the source repo: `--git URL`, else the source recorded at import.
2. Clones it; detects where the agent lives (`agent/` subpath or repo root).
3. Copies the local `agent-manifest.json` + tracked dirs (`skills/ commands/ docs/ scripts/ orchestration/`) over it.
4. Commits on `agentfactory/export-<name>`, pushes, opens a PR.

### Options
`--git URL` · `--subpath` · `--branch` · `-m/--message` · `--project-root` ·
`--push/--no-push` (writes a `.patch`) · `--pr/--no-pr`.

### Also in this PR
- **`import` records the source** (`{"git": url}` / `{"registry": slug}`) in the agent
  manifest, so `export` defaults to it (no need to retype the URL).
- **`--git` accepts local paths / `file://`** — offline use + makes the feature testable
  against a bare repo. (Also a step toward AgentFactory#179 gap 2.)

### Tests
`src/tests/test_export.py` — 5 tests (push-to-recorded-source, explicit `--git`,
no-source error, `--no-push` patch, missing-agent error). **All pass.**

> Full suite: 300 passed, 2 failed — the 2 are pre-existing live external-CLI tests
> (`test_live_agent_acknowledges_harness[gemini/codex]`) failing on Gemini/Codex **auth**,
> confirmed failing on clean `main`. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
